### PR TITLE
feat(beeper): Phase A — searchable Convex backup of Beeper message history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ temp/
 # Local dev artifacts
 .dev-screenshots/
 .superpowers/
+
+# Local progress state for the Beeper sync/upload scripts (per-account, per-machine)
+scripts/.beeper-sync-progress.json
+scripts/.beeper-attachments-progress.json

--- a/app/src/components/DashboardView.tsx
+++ b/app/src/components/DashboardView.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react"
 import { Card } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { api } from "@/convex/_generated/api"
+import { getProjectColor } from "@/lib/colors"
 import { getPriorityColorClass } from "@/lib/priorities"
 import { cn } from "@/lib/utils"
 import type { ViewKey } from "@/lib/views/types"
@@ -85,17 +86,15 @@ export function DashboardView({
         />
       </div>
 
-      {/* Row 3: Top projects + Today's queue */}
+      {/* Row 3: Top projects + Focus queue */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <TopProjectsCard
           projects={stats.topProjects}
           onNavigate={onNavigate}
         />
-        <TodayQueueCard
-          items={stats.todayQueue}
-          onTitleClick={
-            onNavigate ? () => onNavigate("view:today") : undefined
-          }
+        <FocusCard
+          items={stats.focusQueue}
+          onNavigate={onNavigate}
         />
       </div>
     </div>
@@ -194,7 +193,7 @@ function PriorityDistributionCard({
           {counts.total} active
         </div>
       </div>
-      <div className="flex items-end gap-3 h-32">
+      <div className="flex items-stretch gap-3 h-40">
         {bars.map((bar) => {
           const heightPct = (bar.value / max) * 100
           const viewKey = PRIORITY_VIEW_KEYS[bar.label]
@@ -206,16 +205,18 @@ function PriorityDistributionCard({
               disabled={!clickable}
               onClick={onNavigate ? () => onNavigate(viewKey) : undefined}
               className={cn(
-                "flex-1 flex flex-col items-center gap-1.5 rounded-md p-1 text-left",
+                "flex-1 h-full flex flex-col items-center justify-end gap-1.5 rounded-md p-1 text-left",
                 clickable &&
                   "cursor-pointer transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                 !clickable && "cursor-default"
               )}
             >
-              <div className="w-full flex-1 flex items-end">
+              {/* Bar: fixed-position absolute relative to the container is overkill;
+                  simpler — give it a percent height of the parent flex column. */}
+              <div className="w-full flex-1 flex items-end min-h-0">
                 <div
                   className={cn("w-full rounded-t-sm", bar.color)}
-                  style={{ height: `${Math.max(heightPct, 2)}%` }}
+                  style={{ height: `${Math.max(heightPct, 4)}%` }}
                 />
               </div>
               <div className="text-[10px] text-muted-foreground">
@@ -308,6 +309,8 @@ interface TopProjectsCardProps {
     name: string
     color: string
     activeTaskCount: number
+    priority: number | null
+    scheduledDate: string | null
   }>
   onNavigate?: (viewKey: ViewKey) => void
 }
@@ -315,7 +318,7 @@ interface TopProjectsCardProps {
 function TopProjectsCard({ projects, onNavigate }: TopProjectsCardProps) {
   return (
     <Card className="p-5">
-      <div className="text-sm font-medium mb-3">Top projects · active tasks</div>
+      <div className="text-sm font-medium mb-3">Top projects</div>
       {projects.length === 0 ? (
         <div className="text-xs text-muted-foreground">No projects with active tasks</div>
       ) : (
@@ -323,6 +326,10 @@ function TopProjectsCard({ projects, onNavigate }: TopProjectsCardProps) {
           {projects.map((project) => {
             const viewKey: ViewKey = `view:project:${project.todoistId}`
             const clickable = Boolean(onNavigate)
+            const priorityColor =
+              project.priority !== null && project.priority !== undefined
+                ? getPriorityColorClass(project.priority)
+                : null
             return (
               <button
                 key={project.todoistId}
@@ -332,14 +339,25 @@ function TopProjectsCard({ projects, onNavigate }: TopProjectsCardProps) {
                   onNavigate ? () => onNavigate(viewKey) : undefined
                 }
                 className={cn(
-                  "flex justify-between items-center text-sm rounded-md px-2 py-1.5 -mx-2 text-left",
+                  "flex items-center gap-2.5 text-sm rounded-md px-2 py-1.5 -mx-2 text-left",
                   clickable &&
                     "cursor-pointer transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   !clickable && "cursor-default"
                 )}
               >
-                <span className="truncate">{project.name}</span>
-                <span className="text-muted-foreground tabular-nums ml-2">
+                <span
+                  className="h-2.5 w-2.5 rounded-full shrink-0"
+                  style={{ backgroundColor: getProjectColor(project.color) }}
+                  aria-hidden
+                />
+                <span className="truncate flex-1">{project.name}</span>
+                {priorityColor && (
+                  <Flag
+                    className={cn("h-3.5 w-3.5 shrink-0", priorityColor)}
+                    fill="currentColor"
+                  />
+                )}
+                <span className="text-muted-foreground tabular-nums shrink-0 w-10 text-right">
                   {project.activeTaskCount}
                 </span>
               </button>
@@ -351,59 +369,107 @@ function TopProjectsCard({ projects, onNavigate }: TopProjectsCardProps) {
   )
 }
 
-interface TodayQueueCardProps {
+interface FocusCardProps {
   items: Array<{
     todoistId: string
     content: string
     priority: number
-    startTime: string | null
+    projectName: string | null
+    projectColor: string | null
+    dueDate: string | null
+    isOverdue: boolean
   }>
-  onTitleClick?: () => void
+  onNavigate?: (viewKey: ViewKey) => void
 }
 
-function TodayQueueCard({ items, onTitleClick }: TodayQueueCardProps) {
+function formatDueLabel(item: FocusCardProps["items"][number]): string | null {
+  if (!item.dueDate) return null
+  if (item.isOverdue) return "overdue"
+  const today = new Date().toISOString().slice(0, 10)
+  if (item.dueDate === today) return "today"
+  // Lightweight relative format: "May 20" or "Aug 3"
+  const [, m, d] = item.dueDate.split("-").map((s) => parseInt(s, 10))
+  const month = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ][m - 1]
+  return `${month} ${d}`
+}
+
+function FocusCard({ items, onNavigate }: FocusCardProps) {
+  const titleClickable = Boolean(onNavigate)
   return (
     <Card className="p-5">
-      {onTitleClick ? (
+      {titleClickable ? (
         <button
           type="button"
-          onClick={onTitleClick}
+          onClick={() => onNavigate?.("view:priority:p1")}
           className="text-sm font-medium mb-3 text-left rounded-md cursor-pointer hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          Today · what&apos;s next →
+          Focus · what&apos;s next →
         </button>
       ) : (
-        <div className="text-sm font-medium mb-3">Today · what&apos;s next</div>
+        <div className="text-sm font-medium mb-3">Focus · what&apos;s next</div>
       )}
       {items.length === 0 ? (
         <div className="text-xs text-muted-foreground">
-          Nothing scheduled for today
+          Nothing active. Inbox zero achieved.
         </div>
       ) : (
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-0.5">
           {items.map((item) => {
             const colorClass = getPriorityColorClass(item.priority)
             const showFlag = item.priority >= 2
+            const dueLabel = formatDueLabel(item)
             return (
               <div
                 key={item.todoistId}
-                className="flex justify-between items-center text-sm gap-2"
+                className="flex items-center gap-2 text-sm px-2 py-1.5 -mx-2"
               >
-                <div className="flex items-center gap-2 min-w-0">
-                  {item.startTime ? (
-                    <span className="text-muted-foreground tabular-nums text-xs w-10 shrink-0">
-                      {item.startTime}
-                    </span>
-                  ) : (
-                    <span className="w-10 shrink-0" />
-                  )}
-                  <span className="truncate">{item.content}</span>
-                </div>
-                {showFlag && (
+                {showFlag ? (
                   <Flag
                     className={cn("h-3.5 w-3.5 shrink-0", colorClass)}
                     fill="currentColor"
                   />
+                ) : (
+                  <span className="h-3.5 w-3.5 shrink-0" />
+                )}
+                <span className="truncate flex-1">{item.content}</span>
+                {item.projectName && (
+                  <span className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0 min-w-0 max-w-[40%]">
+                    {item.projectColor && (
+                      <span
+                        className="h-1.5 w-1.5 rounded-full shrink-0"
+                        style={{
+                          backgroundColor: getProjectColor(item.projectColor),
+                        }}
+                        aria-hidden
+                      />
+                    )}
+                    <span className="truncate">{item.projectName}</span>
+                  </span>
+                )}
+                {dueLabel && (
+                  <span
+                    className={cn(
+                      "text-xs shrink-0 tabular-nums w-14 text-right",
+                      item.isOverdue
+                        ? "text-red-500 dark:text-red-400"
+                        : "text-muted-foreground"
+                    )}
+                  >
+                    {dueLabel}
+                  </span>
                 )}
               </div>
             )

--- a/convex/beeper/README.md
+++ b/convex/beeper/README.md
@@ -97,7 +97,46 @@ That's the laptop or Mac Mini running `bun run scripts/sync-beeper.ts`. Real-tim
 
 ## Phase plan
 
-- **Phase A** (this directory, shipped): Schema + ingest + local script + sync of chats/messages metadata.
-- **Phase B** (next): Upload referenced attachments (~29 GB across all networks) to Convex File Storage. Adds dedup by `mxc_id`, a `generateUploadUrl` mutation, and a parallel/resumable uploader.
+- **Phase A** (shipped): Schema + ingest + local script + sync of chats/messages metadata.
+- **Phase B** (shipped): Upload referenced attachments to Convex File Storage. Dedupes by Matrix `mxc_id` so a media file shared across many messages (forwards, group blasts) is uploaded once.
 - **Phase C** (later): Long-running WS subscriber for realtime updates, run via launchd on the Mac Mini.
-- **Phase D** (later): Other networks (`--account telegram`, `--account local-telegram_...`, `slackgo.*`, etc.) — same script, no schema changes needed.
+- **Phase D** (later): Other networks (`--account telegram`, `--account local-telegram_...`, `slackgo.*`, etc.) — same scripts, no schema changes needed.
+
+## Phase B — attachment pipeline
+
+Beeper Desktop caches every attachment locally under `~/Library/Application Support/BeeperTexts/media/<homeserver>/<key>`. Each message we ingest in Phase A carries a `mxc_id` per attachment that points back into that cache. Phase B walks every chat once, collects every unique `mxc_id`, and uploads the referenced bytes into Convex File Storage.
+
+Three HTTP routes are added (all share the same `BEEPER_INGEST_SECRET` bearer auth as `/beeper/ingest`):
+
+| Route                              | Body                            | Purpose |
+| ---------------------------------- | ------------------------------- | ------- |
+| `POST /beeper/attachments/discover`  | `{ mxc_ids: string[] }`         | Partition into already-uploaded vs missing — drives resumability. |
+| `POST /beeper/attachments/uploadUrl` | `{}`                            | Returns a short-lived single-use URL the uploader POSTs file bytes to. |
+| `POST /beeper/attachments/record`    | `{ mxc_id, convex_storage_id, network, mime_type?, ... }` | Persists the mapping in `beeper_attachments`. |
+
+The new `beeper_attachments` table is the single source of truth for "where are the bytes" — `beeper_messages.attachments[].convex_storage_id` is intentionally left unpopulated so the messages table stays immutable post-Phase-A. Reads join through `getAttachmentUrl(mxc_id)`.
+
+### Running the Phase B uploader
+
+```bash
+cd ~/Programming/Repos/convex-db
+eval "$(op read 'op://Sol/Beeper Env/notesPlain')"
+source <(grep -E '^(BEEPER_URL|BEEPER_INGEST_SECRET)=' .env.local)
+export CONVEX_INGEST_URL="https://blessed-egret-906.convex.site/beeper/ingest"
+
+bun run scripts/upload-beeper-attachments.ts --limit 10 --dry-run   # smoke test
+bun run scripts/upload-beeper-attachments.ts                        # full WhatsApp
+bun run scripts/upload-beeper-attachments.ts --account gmessages    # later networks
+```
+
+Progress lives at `scripts/.beeper-attachments-progress.json`: per-account map of `mxc_id → convex_storage_id` plus a `failed` map of `mxc_id → last error`. Re-runs ask Convex's `/discover` endpoint up front so already-uploaded files are skipped without any local state.
+
+### Resolving an attachment
+
+```bash
+bunx convex run beeper/queries/getAttachmentUrl:getAttachmentUrl \
+  '{"mxc_id":"mxc://local.beeper.com/...xxx"}'
+# → { mxc_id, convex_storage_id, url, mime_type, file_name, file_size }
+```
+
+`url` is a short-lived signed URL from `ctx.storage.getUrl(...)`; refetch on every render rather than persist it.

--- a/convex/beeper/README.md
+++ b/convex/beeper/README.md
@@ -1,0 +1,103 @@
+# Beeper Integration
+
+Mirror of Milad's Beeper Desktop message history into Convex for searchable, durable backup across all bridged networks (WhatsApp, Telegram, iMessage, Slack, Google Messages, Matrix).
+
+Built as the second-class citizen alongside the Todoist integration. Same general shape (schema/queries/mutations/sync/types) with one major difference: **the source of truth (Beeper Desktop) is local-only**, so ingest is pushed from a local script rather than pulled by a Convex action.
+
+## Pipeline
+
+```
+Beeper Desktop (localhost:23373) ──┐
+                                   │  (1) HTTP GET — list chats, list messages
+                                   ▼
+scripts/sync-beeper.ts (on Milad's Mac, Bun)
+                                   │  (2) HTTP POST — batched payloads
+                                   ▼
+POST /beeper/ingest (Convex httpAction)
+                                   │  (3) ctx.runMutation(...)
+                                   ▼
+beeper.internalMutations.{upsertAccount, upsertChat, upsertMessages, markAccountSynced}
+                                   │
+                                   ▼
+beeper_accounts / beeper_chats / beeper_messages
+```
+
+## Tables
+
+| Table              | Identity              | Notes |
+| ------------------ | --------------------- | ----- |
+| `beeper_accounts`  | `account_id`          | One row per Beeper-connected network |
+| `beeper_chats`     | `chat_id`             | Beeper/Matrix room id, globally unique |
+| `beeper_messages`  | `(chat_id, msg_id)`   | Beeper message ids are only chat-local |
+
+`beeper_messages` has a `searchIndex` on `text` with filters on `chat_id`, `network`, `sender_id`, `is_sender`, `type`.
+
+Attachments are stored inline on each message row as `attachments: { mxc_id, mime_type, file_name, beeper_src_url, convex_storage_id?, ... }[]`. Phase A stores everything except `convex_storage_id`; Phase B (separate task) uploads bytes to Convex File Storage and patches that field in place using `mxc_id` as the dedupe key across chats.
+
+## Auth
+
+`POST /beeper/ingest` requires `Authorization: Bearer <BEEPER_INGEST_SECRET>`. The same value lives in:
+
+- Convex env: `BEEPER_INGEST_SECRET` (set via `bunx convex env set`)
+- Local `.env.local` for the sync script
+
+If the env var is unset on the deployment, the endpoint returns 500 with a clear error — fail closed, never accept writes.
+
+## Running
+
+```bash
+# One-time prep: set the shared secret on the deployment
+bunx convex env set BEEPER_INGEST_SECRET "$(openssl rand -hex 32)"
+
+# Local .env.local needs (alongside CONVEX_URL etc.):
+#   BEEPER_URL=http://localhost:23373/v1
+#   BEEPER_ACCESS_TOKEN=...                                 # from Beeper Desktop > Developers
+#   CONVEX_INGEST_URL=https://<deployment>.convex.site/beeper/ingest
+#   BEEPER_INGEST_SECRET=<same as the one above>
+
+# Smoke test (5 chats only, no Convex writes)
+bun run scripts/sync-beeper.ts --limit-chats 5 --dry-run
+
+# Smoke test (5 chats, real writes)
+bun run scripts/sync-beeper.ts --limit-chats 5
+
+# Full WhatsApp backfill (resumable)
+bun run scripts/sync-beeper.ts
+```
+
+Progress is tracked per-account in `scripts/.beeper-sync-progress.json`. Re-running skips already-completed chats; pass `--refresh` to re-fetch everything.
+
+## Common Queries
+
+```bash
+# Sync health across all networks
+bunx convex run beeper:queries.getSyncStatus.getSyncStatus
+
+# Recent chats (any network)
+bunx convex run beeper:queries.getRecentChats.getRecentChats '{"limit": 20}'
+
+# Recent chats (WhatsApp only)
+bunx convex run beeper:queries.getRecentChats.getRecentChats '{"network": "WhatsApp", "limit": 20}'
+
+# Messages for a specific chat
+bunx convex run beeper:queries.getMessagesByChat.getMessagesByChat '{"chat_id": "!9iCfip38rzlgcROX7VP3:beeper.local"}'
+
+# Full-text search
+bunx convex run beeper:queries.searchMessages.searchMessages '{"query": "umbrella weekend", "network": "WhatsApp"}'
+```
+
+## Why local-push instead of Convex-pull
+
+Beeper's API only exists at `localhost:23373` on Milad's machines. Convex actions run in a Convex-hosted runtime that cannot reach Milad's localhost. So ingest has to originate on a machine that has both:
+
+1. A logged-in Beeper Desktop with the API enabled.
+2. Network access to the Convex deployment.
+
+That's the laptop or Mac Mini running `bun run scripts/sync-beeper.ts`. Real-time updates (Phase C, not yet built) will use Beeper's WebSocket subscription (`ws://localhost:23373/v1/ws`) on the same local script, streaming `message.upserted` events into the same ingest endpoint.
+
+## Phase plan
+
+- **Phase A** (this directory, shipped): Schema + ingest + local script + sync of chats/messages metadata.
+- **Phase B** (next): Upload referenced attachments (~29 GB across all networks) to Convex File Storage. Adds dedup by `mxc_id`, a `generateUploadUrl` mutation, and a parallel/resumable uploader.
+- **Phase C** (later): Long-running WS subscriber for realtime updates, run via launchd on the Mac Mini.
+- **Phase D** (later): Other networks (`--account telegram`, `--account local-telegram_...`, `slackgo.*`, etc.) — same script, no schema changes needed.

--- a/convex/beeper/internalMutations/generateUploadUrl.ts
+++ b/convex/beeper/internalMutations/generateUploadUrl.ts
@@ -1,0 +1,12 @@
+import { internalMutation } from "../../_generated/server";
+
+/**
+ * Issue a short-lived upload URL that the local uploader script POSTs file
+ * bytes to. The returned URL is single-use and Convex auto-expires it; we
+ * never persist it.
+ */
+export const generateUploadUrl = internalMutation({
+  handler: async (ctx) => {
+    return await ctx.storage.generateUploadUrl();
+  },
+});

--- a/convex/beeper/internalMutations/markAccountSynced.ts
+++ b/convex/beeper/internalMutations/markAccountSynced.ts
@@ -1,0 +1,49 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+
+/**
+ * Stamp `last_full_sync_at` / `last_incremental_sync_at` on the account after
+ * a sync run completes. Also touches the shared `sync_state` table so the
+ * dashboard's generic sync widget can see it.
+ */
+export const markAccountSynced = internalMutation({
+  args: {
+    account_id: v.string(),
+    sync_type: v.union(v.literal("full"), v.literal("incremental")),
+  },
+  handler: async (ctx, { account_id, sync_type }) => {
+    const now = new Date().toISOString();
+
+    const account = await ctx.db
+      .query("beeper_accounts")
+      .withIndex("by_account_id", (q) => q.eq("account_id", account_id))
+      .first();
+    if (!account) {
+      throw new Error(`markAccountSynced: no account with id ${account_id}`);
+    }
+    await ctx.db.patch(account._id, {
+      last_full_sync_at:
+        sync_type === "full" ? now : account.last_full_sync_at,
+      last_incremental_sync_at: now,
+    });
+
+    const service = `beeper-${account.network.toLowerCase().replace(/\s+/g, "")}`;
+    const existing = await ctx.db
+      .query("sync_state")
+      .withIndex("by_service", (q) => q.eq("service", service))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        last_full_sync: sync_type === "full" ? now : existing.last_full_sync,
+        last_incremental_sync: now,
+      });
+    } else {
+      await ctx.db.insert("sync_state", {
+        service,
+        last_full_sync: now,
+        last_incremental_sync: now,
+      });
+    }
+  },
+});

--- a/convex/beeper/internalMutations/recordAttachment.test.ts
+++ b/convex/beeper/internalMutations/recordAttachment.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+
+describe("recordAttachment transform", () => {
+  test("inserts new row when no existing row for mxc_id", () => {
+    const args = {
+      mxc_id: "mxc://local.beeper.com/abc",
+      convex_storage_id: "kg_new",
+      network: "WhatsApp",
+      mime_type: "image/jpeg",
+      file_size: 12345,
+    };
+    const row = {
+      ...args,
+      uploaded_at: new Date().toISOString(),
+    };
+    expect(row.mxc_id).toBe(args.mxc_id);
+    expect(row.convex_storage_id).toBe("kg_new");
+    expect(row.uploaded_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("on race: incoming duplicate storage id is deleted, existing wins", () => {
+    const existing = { convex_storage_id: "kg_first" };
+    const incoming = { convex_storage_id: "kg_dup" };
+    const willDelete = existing.convex_storage_id !== incoming.convex_storage_id;
+    expect(willDelete).toBe(true);
+  });
+
+  test("on race: identical storage id is a no-op (deduped on retry)", () => {
+    const existing = { convex_storage_id: "kg_same" };
+    const incoming = { convex_storage_id: "kg_same" };
+    const willDelete = existing.convex_storage_id !== incoming.convex_storage_id;
+    expect(willDelete).toBe(false);
+  });
+});

--- a/convex/beeper/internalMutations/recordAttachment.ts
+++ b/convex/beeper/internalMutations/recordAttachment.ts
@@ -1,0 +1,54 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+
+/**
+ * Register a uniquely-identified media file after its bytes have been
+ * uploaded to Convex File Storage by the local uploader script.
+ *
+ * Idempotent: if a row already exists for this mxc_id we DELETE the
+ * newly-uploaded storage object (the caller's upload) before patching the
+ * row, so duplicates don't accumulate in storage. The pre-existing
+ * convex_storage_id is what stays referenced.
+ */
+export const recordAttachment = internalMutation({
+  args: {
+    mxc_id: v.string(),
+    convex_storage_id: v.string(),
+    network: v.string(),
+    mime_type: v.optional(v.string()),
+    file_name: v.optional(v.string()),
+    file_size: v.optional(v.number()),
+    width: v.optional(v.number()),
+    height: v.optional(v.number()),
+    duration_ms: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("beeper_attachments")
+      .withIndex("by_mxc_id", (q) => q.eq("mxc_id", args.mxc_id))
+      .first();
+
+    if (existing) {
+      // Lost the race — somebody else already uploaded this mxc_id. Free our
+      // duplicate so we don't leak storage bytes.
+      if (existing.convex_storage_id !== args.convex_storage_id) {
+        await ctx.storage.delete(args.convex_storage_id);
+      }
+      return existing._id;
+    }
+
+    return await ctx.db.insert("beeper_attachments", {
+      mxc_id: args.mxc_id,
+      convex_storage_id: args.convex_storage_id,
+      network: args.network,
+      mime_type: args.mime_type,
+      file_name: args.file_name,
+      file_size: args.file_size,
+      width: args.width,
+      height: args.height,
+      duration_ms: args.duration_ms,
+      uploaded_at: new Date().toISOString(),
+    });
+  },
+});

--- a/convex/beeper/internalMutations/upsertAccount.test.ts
+++ b/convex/beeper/internalMutations/upsertAccount.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+
+describe("upsertAccount transform", () => {
+  test("is_active defaults to true when omitted", () => {
+    const account = { is_active: undefined };
+    expect(account.is_active ?? true).toBe(true);
+  });
+
+  test("mark_full_sync_started stamps current time", () => {
+    const before = Date.now();
+    const now = new Date().toISOString();
+    const markSync: boolean = true;
+    const stamped = markSync ? now : undefined;
+    expect(typeof stamped).toBe("string");
+    expect(new Date(stamped!).getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  test("when mark_full_sync_started is false, prior timestamp is preserved", () => {
+    const existing = { last_full_sync_at: "2025-01-01T00:00:00.000Z" };
+    const markSync: boolean = false;
+    const next = markSync ? new Date().toISOString() : existing.last_full_sync_at;
+    expect(next).toBe("2025-01-01T00:00:00.000Z");
+  });
+});

--- a/convex/beeper/internalMutations/upsertAccount.ts
+++ b/convex/beeper/internalMutations/upsertAccount.ts
@@ -1,0 +1,44 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+import { ingestAccountSchema } from "../types/ingestApi";
+
+/**
+ * Idempotent upsert of a Beeper account row. Keyed by `account_id`
+ * (Beeper's internal identifier, e.g. "whatsapp", "telegram").
+ *
+ * Touches `last_full_sync_at` so callers can use this as a sync heartbeat at
+ * the start of a full backfill.
+ */
+export const upsertAccount = internalMutation({
+  args: {
+    account: ingestAccountSchema,
+    mark_full_sync_started: v.optional(v.boolean()),
+  },
+  handler: async (ctx, { account, mark_full_sync_started }) => {
+    const existing = await ctx.db
+      .query("beeper_accounts")
+      .withIndex("by_account_id", (q) => q.eq("account_id", account.account_id))
+      .first();
+
+    const now = new Date().toISOString();
+    const row = {
+      account_id: account.account_id,
+      network: account.network,
+      display_name: account.display_name,
+      phone_number: account.phone_number,
+      is_active: account.is_active ?? true,
+      last_full_sync_at: mark_full_sync_started
+        ? now
+        : existing?.last_full_sync_at,
+      last_incremental_sync_at: existing?.last_incremental_sync_at,
+      raw: account.raw,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, row);
+      return existing._id;
+    }
+    return await ctx.db.insert("beeper_accounts", row);
+  },
+});

--- a/convex/beeper/internalMutations/upsertChat.test.ts
+++ b/convex/beeper/internalMutations/upsertChat.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+describe("upsertChat transform", () => {
+  test("derives epoch ms from last_activity ISO string", () => {
+    const iso = "2026-05-22T22:26:41.000Z";
+    expect(new Date(iso).getTime()).toBe(Date.UTC(2026, 4, 22, 22, 26, 41));
+  });
+
+  test("participant_count is derived from participants length", () => {
+    const participants = [
+      { id: "@a:beeper.local" },
+      { id: "@b:beeper.local" },
+      { id: "@c:beeper.local" },
+    ];
+    expect(participants.length).toBe(3);
+  });
+
+  test("optional boolean flags default to false", () => {
+    const chat = { is_archived: undefined, is_muted: undefined };
+    expect(chat.is_archived ?? false).toBe(false);
+    expect(chat.is_muted ?? false).toBe(false);
+  });
+
+  test("first_seen_at is preserved on update, last_synced_at always bumped", () => {
+    const existing = {
+      first_seen_at: "2025-01-01T00:00:00.000Z",
+      last_synced_at: "2025-06-01T00:00:00.000Z",
+    };
+    const now = "2026-05-22T00:00:00.000Z";
+    const merged = {
+      first_seen_at: existing.first_seen_at ?? now,
+      last_synced_at: now,
+    };
+    expect(merged.first_seen_at).toBe("2025-01-01T00:00:00.000Z");
+    expect(merged.last_synced_at).toBe(now);
+  });
+});

--- a/convex/beeper/internalMutations/upsertChat.ts
+++ b/convex/beeper/internalMutations/upsertChat.ts
@@ -1,0 +1,57 @@
+import { internalMutation } from "../../_generated/server";
+import { ingestChatSchema } from "../types/ingestApi";
+
+/**
+ * Idempotent upsert of a chat row. Keyed by `chat_id` (Beeper/Matrix room id).
+ *
+ * Versioning: we don't get a monotonic version field for chats, so we use
+ * `last_activity` as the freshness signal. Newer activity always wins; equal
+ * activity overwrites (cheap, and covers cases where participant changes
+ * happen without a new message).
+ */
+export const upsertChat = internalMutation({
+  args: {
+    chat: ingestChatSchema,
+  },
+  handler: async (ctx, { chat }) => {
+    const existing = await ctx.db
+      .query("beeper_chats")
+      .withIndex("by_chat_id", (q) => q.eq("chat_id", chat.chat_id))
+      .first();
+
+    const now = new Date().toISOString();
+    const lastActivityEpoch = chat.last_activity
+      ? new Date(chat.last_activity).getTime()
+      : undefined;
+
+    const row = {
+      account_id: chat.account_id,
+      network: chat.network,
+      chat_id: chat.chat_id,
+      local_chat_id: chat.local_chat_id,
+      title: chat.title,
+      description: chat.description,
+      type: chat.type,
+      img_url: chat.img_url,
+      participants: chat.participants,
+      participant_count: chat.participants.length,
+      last_activity: chat.last_activity,
+      last_activity_epoch_ms: lastActivityEpoch,
+      is_archived: chat.is_archived ?? false,
+      is_muted: chat.is_muted ?? false,
+      is_pinned: chat.is_pinned ?? false,
+      is_read_only: chat.is_read_only ?? false,
+      unread_count: chat.unread_count ?? 0,
+      first_seen_at: existing?.first_seen_at ?? now,
+      last_synced_at: now,
+      message_count: existing?.message_count ?? 0,
+      raw: chat.raw,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, row);
+      return existing._id;
+    }
+    return await ctx.db.insert("beeper_chats", row);
+  },
+});

--- a/convex/beeper/internalMutations/upsertMessages.test.ts
+++ b/convex/beeper/internalMutations/upsertMessages.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest";
+
+// Pure helpers copied/duplicated from upsertMessages.ts so we test the
+// transformation logic without needing convex-test scaffolding.
+
+type Attachment = {
+  mxc_id: string;
+  convex_storage_id?: string;
+  mime_type?: string;
+};
+
+function mergeAttachments(prev: Attachment[], next: Attachment[]): Attachment[] {
+  if (!prev.length) return next;
+  const prevById = new Map<string, Attachment>();
+  for (const a of prev) prevById.set(a.mxc_id, a);
+  return next.map((n) => {
+    const old = prevById.get(n.mxc_id);
+    if (old?.convex_storage_id && !n.convex_storage_id) {
+      return { ...n, convex_storage_id: old.convex_storage_id };
+    }
+    return n;
+  });
+}
+
+describe("upsertMessages.mergeAttachments", () => {
+  test("returns `next` unchanged when there is no prior row", () => {
+    const next = [{ mxc_id: "mxc://x", mime_type: "image/jpeg" }];
+    expect(mergeAttachments([], next)).toEqual(next);
+  });
+
+  test("carries forward convex_storage_id from prev when next lacks it", () => {
+    const prev: Attachment[] = [
+      { mxc_id: "mxc://a", convex_storage_id: "kg_abc" },
+    ];
+    const next: Attachment[] = [
+      { mxc_id: "mxc://a", mime_type: "image/jpeg" },
+    ];
+    const merged = mergeAttachments(prev, next);
+    expect(merged[0]?.convex_storage_id).toBe("kg_abc");
+    expect(merged[0]?.mime_type).toBe("image/jpeg");
+  });
+
+  test("does not overwrite a fresh storage_id on next", () => {
+    const prev: Attachment[] = [
+      { mxc_id: "mxc://a", convex_storage_id: "kg_old" },
+    ];
+    const next: Attachment[] = [
+      { mxc_id: "mxc://a", convex_storage_id: "kg_new" },
+    ];
+    const merged = mergeAttachments(prev, next);
+    expect(merged[0]?.convex_storage_id).toBe("kg_new");
+  });
+
+  test("only merges on matching mxc_id", () => {
+    const prev: Attachment[] = [
+      { mxc_id: "mxc://old", convex_storage_id: "kg_old" },
+    ];
+    const next: Attachment[] = [{ mxc_id: "mxc://new" }];
+    const merged = mergeAttachments(prev, next);
+    expect(merged[0]?.convex_storage_id).toBeUndefined();
+  });
+});
+
+describe("upsertMessages transform", () => {
+  test("text defaults to empty string for media-only messages", () => {
+    const undef: string | undefined = undefined;
+    const nul: string | null = null;
+    expect(undef ?? "").toBe("");
+    expect(nul ?? "").toBe("");
+  });
+
+  test("derives ts_epoch_ms from ISO timestamp", () => {
+    expect(new Date("2026-05-22T22:26:41.000Z").getTime()).toBe(
+      Date.UTC(2026, 4, 22, 22, 26, 41),
+    );
+  });
+
+  test("chat_id mismatch throws", () => {
+    const expected = "!room:beeper.local";
+    const msg = { chat_id: "!other:beeper.local", message_id: "1" };
+    expect(() => {
+      if (msg.chat_id !== expected) {
+        throw new Error(
+          `upsertMessages: message ${msg.message_id} has chat_id ${msg.chat_id}, expected ${expected}`,
+        );
+      }
+    }).toThrow(/expected !room/);
+  });
+});

--- a/convex/beeper/internalMutations/upsertMessages.ts
+++ b/convex/beeper/internalMutations/upsertMessages.ts
@@ -1,0 +1,131 @@
+import { v } from "convex/values";
+
+import { internalMutation } from "../../_generated/server";
+import { ingestMessageSchema } from "../types/ingestApi";
+
+/**
+ * Batch upsert of messages for ONE chat. Keyed by (chat_id, message_id).
+ *
+ * Versioning: we treat sort_key as the version. Beeper assigns a globally
+ * monotonic numeric sort_key per chat; any same-key row coming back from
+ * Beeper after we already have it represents either a no-op duplicate or an
+ * edit (we accept the latter and overwrite, since attempts at field-level
+ * version reasoning would lose reactions/edits).
+ *
+ * Also bumps `beeper_chats.message_count` to reflect the row count for the
+ * chat after the upsert (best-effort cache; not authoritative for analytics).
+ */
+export const upsertMessages = internalMutation({
+  args: {
+    chat_id: v.string(),
+    messages: v.array(ingestMessageSchema),
+  },
+  handler: async (ctx, { chat_id, messages }) => {
+    const now = new Date().toISOString();
+    let inserted = 0;
+    let updated = 0;
+
+    for (const msg of messages) {
+      if (msg.chat_id !== chat_id) {
+        // Caller batches by chat; mismatch is a bug worth surfacing.
+        throw new Error(
+          `upsertMessages: message ${msg.message_id} has chat_id ${msg.chat_id}, expected ${chat_id}`,
+        );
+      }
+
+      const existing = await ctx.db
+        .query("beeper_messages")
+        .withIndex("by_chat_message", (q) =>
+          q.eq("chat_id", msg.chat_id).eq("message_id", msg.message_id),
+        )
+        .first();
+
+      const tsEpoch = msg.timestamp
+        ? new Date(msg.timestamp).getTime()
+        : undefined;
+
+      const row = {
+        account_id: msg.account_id,
+        network: msg.network,
+        chat_id: msg.chat_id,
+        message_id: msg.message_id,
+        sort_key: msg.sort_key,
+        sender_id: msg.sender_id,
+        sender_name: msg.sender_name,
+        is_sender: msg.is_sender ?? false,
+        timestamp: msg.timestamp,
+        ts_epoch_ms: tsEpoch,
+        type: msg.type,
+        text: msg.text ?? "",
+        reactions: msg.reactions ?? [],
+        attachments: existing
+          ? mergeAttachments(existing.attachments, msg.attachments ?? [])
+          : (msg.attachments ?? []),
+        reply_to_message_id: msg.reply_to_message_id,
+        is_deleted: msg.is_deleted ?? false,
+        is_hidden: msg.is_hidden ?? false,
+        first_seen_at: existing?.first_seen_at ?? now,
+        last_synced_at: now,
+        raw: msg.raw,
+      };
+
+      if (existing) {
+        await ctx.db.patch(existing._id, row);
+        updated += 1;
+      } else {
+        await ctx.db.insert("beeper_messages", row);
+        inserted += 1;
+      }
+    }
+
+    // Update message_count on the chat (best-effort cache).
+    const chat = await ctx.db
+      .query("beeper_chats")
+      .withIndex("by_chat_id", (q) => q.eq("chat_id", chat_id))
+      .first();
+    if (chat) {
+      const all = await ctx.db
+        .query("beeper_messages")
+        .withIndex("by_chat_recent", (q) => q.eq("chat_id", chat_id))
+        .collect();
+      await ctx.db.patch(chat._id, {
+        message_count: all.length,
+        last_synced_at: now,
+      });
+    }
+
+    return { inserted, updated };
+  },
+});
+
+/**
+ * Preserve `convex_storage_id` that Phase B wrote onto attachments even if
+ * Phase A re-ingests the same message later. Match by `mxc_id`.
+ */
+type Attachment = {
+  mxc_id: string;
+  type?: string;
+  mime_type?: string;
+  file_name?: string;
+  file_size?: number;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+  is_gif?: boolean;
+  is_sticker?: boolean;
+  beeper_src_url?: string;
+  convex_storage_id?: string;
+};
+
+function mergeAttachments(prev: Attachment[], next: Attachment[]): Attachment[] {
+  if (!prev.length) return next;
+  const prevById = new Map<string, Attachment>();
+  for (const a of prev) prevById.set(a.mxc_id, a);
+  return next.map((n) => {
+    const old = prevById.get(n.mxc_id);
+    if (old?.convex_storage_id && !n.convex_storage_id) {
+      return { ...n, convex_storage_id: old.convex_storage_id };
+    }
+    return n;
+  });
+}

--- a/convex/beeper/queries/discoverAttachments.test.ts
+++ b/convex/beeper/queries/discoverAttachments.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+describe("discoverAttachments partition", () => {
+  test("splits input into uploaded vs missing based on existing rows", () => {
+    const existing = new Map([
+      ["mxc://a", "kg_a"],
+      ["mxc://b", "kg_b"],
+    ]);
+    const input = ["mxc://a", "mxc://b", "mxc://c", "mxc://d"];
+
+    const uploaded: { mxc_id: string; convex_storage_id: string }[] = [];
+    const missing: string[] = [];
+    for (const mxc_id of input) {
+      const sid = existing.get(mxc_id);
+      if (sid) uploaded.push({ mxc_id, convex_storage_id: sid });
+      else missing.push(mxc_id);
+    }
+
+    expect(uploaded).toEqual([
+      { mxc_id: "mxc://a", convex_storage_id: "kg_a" },
+      { mxc_id: "mxc://b", convex_storage_id: "kg_b" },
+    ]);
+    expect(missing).toEqual(["mxc://c", "mxc://d"]);
+  });
+
+  test("empty input → empty output", () => {
+    const uploaded: unknown[] = [];
+    const missing: unknown[] = [];
+    expect(uploaded.length).toBe(0);
+    expect(missing.length).toBe(0);
+  });
+});

--- a/convex/beeper/queries/discoverAttachments.ts
+++ b/convex/beeper/queries/discoverAttachments.ts
@@ -1,0 +1,39 @@
+import { v } from "convex/values";
+
+import { internalQuery } from "../../_generated/server";
+
+/**
+ * Given a batch of mxc_ids, return which ones are already in Convex File
+ * Storage (so the local uploader can skip them) and which ones still need
+ * uploading.
+ *
+ * The uploader calls this in 200-id chunks at the start of every run; the
+ * skipped set typically grows to 100% on a resumed run, making re-runs
+ * basically free.
+ */
+export const discoverAttachments = internalQuery({
+  args: {
+    mxc_ids: v.array(v.string()),
+  },
+  handler: async (ctx, { mxc_ids }) => {
+    const uploaded: { mxc_id: string; convex_storage_id: string }[] = [];
+    const missing: string[] = [];
+
+    for (const mxc_id of mxc_ids) {
+      const row = await ctx.db
+        .query("beeper_attachments")
+        .withIndex("by_mxc_id", (q) => q.eq("mxc_id", mxc_id))
+        .first();
+      if (row) {
+        uploaded.push({
+          mxc_id: row.mxc_id,
+          convex_storage_id: row.convex_storage_id,
+        });
+      } else {
+        missing.push(mxc_id);
+      }
+    }
+
+    return { uploaded, missing };
+  },
+});

--- a/convex/beeper/queries/getAttachmentUrl.test.ts
+++ b/convex/beeper/queries/getAttachmentUrl.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+describe("getAttachmentUrl projection", () => {
+  test("returns null when no row exists for mxc_id", () => {
+    const row = undefined;
+    expect(row ?? null).toBe(null);
+  });
+
+  test("projects expected fields when row + url are present", () => {
+    const row = {
+      mxc_id: "mxc://a",
+      convex_storage_id: "kg_a",
+      mime_type: "image/jpeg",
+      file_name: "image.jpg",
+      file_size: 12345,
+    };
+    const url = "https://blessed-egret-906.convex.cloud/api/storage/x";
+    const projected = {
+      mxc_id: row.mxc_id,
+      convex_storage_id: row.convex_storage_id,
+      url,
+      mime_type: row.mime_type,
+      file_name: row.file_name,
+      file_size: row.file_size,
+    };
+    expect(projected.url).toContain("convex.cloud");
+    expect(projected.mxc_id).toBe("mxc://a");
+  });
+});

--- a/convex/beeper/queries/getAttachmentUrl.ts
+++ b/convex/beeper/queries/getAttachmentUrl.ts
@@ -1,0 +1,31 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+
+/**
+ * Resolve an mxc_id to a short-lived Convex File Storage URL. Returns null
+ * when the file hasn't been uploaded yet (Phase B not run for it, or the
+ * attachment never made it into the dedupe table).
+ *
+ * URLs returned by `ctx.storage.getUrl` expire after a short window; callers
+ * should re-fetch on each render rather than persist the URL.
+ */
+export const getAttachmentUrl = query({
+  args: { mxc_id: v.string() },
+  handler: async (ctx, { mxc_id }) => {
+    const row = await ctx.db
+      .query("beeper_attachments")
+      .withIndex("by_mxc_id", (q) => q.eq("mxc_id", mxc_id))
+      .first();
+    if (!row) return null;
+    const url = await ctx.storage.getUrl(row.convex_storage_id);
+    return {
+      mxc_id: row.mxc_id,
+      convex_storage_id: row.convex_storage_id,
+      url,
+      mime_type: row.mime_type,
+      file_name: row.file_name,
+      file_size: row.file_size,
+    };
+  },
+});

--- a/convex/beeper/queries/getMessagesByChat.test.ts
+++ b/convex/beeper/queries/getMessagesByChat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+
+describe("getMessagesByChat projection", () => {
+  test("default limit is 100", () => {
+    const limit = undefined as number | undefined;
+    expect(limit ?? 100).toBe(100);
+  });
+
+  test("before_ts_epoch_ms acts as exclusive upper bound for keyset pagination", () => {
+    const all = [
+      { ts_epoch_ms: 1000 },
+      { ts_epoch_ms: 2000 },
+      { ts_epoch_ms: 3000 },
+    ];
+    const before = 2500;
+    const page = all.filter((m) => m.ts_epoch_ms < before);
+    expect(page.length).toBe(2);
+    expect(page.map((m) => m.ts_epoch_ms)).toEqual([1000, 2000]);
+  });
+});

--- a/convex/beeper/queries/getMessagesByChat.ts
+++ b/convex/beeper/queries/getMessagesByChat.ts
@@ -1,0 +1,47 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+
+/**
+ * Messages for one chat, ordered by ts_epoch_ms. Default newest-first.
+ *
+ * For pagination, callers pass `before_ts_epoch_ms` (the oldest ts they have)
+ * and we return the next page going backwards.
+ */
+export const getMessagesByChat = query({
+  args: {
+    chat_id: v.string(),
+    before_ts_epoch_ms: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 100;
+
+    const before = args.before_ts_epoch_ms;
+    const rows = await ctx.db
+      .query("beeper_messages")
+      .withIndex("by_chat_recent", (q) =>
+        before !== undefined
+          ? q.eq("chat_id", args.chat_id).lt("ts_epoch_ms", before)
+          : q.eq("chat_id", args.chat_id),
+      )
+      .order("desc")
+      .take(limit);
+
+    return rows.map((m) => ({
+      _id: m._id,
+      message_id: m.message_id,
+      sender_id: m.sender_id,
+      sender_name: m.sender_name,
+      is_sender: m.is_sender,
+      timestamp: m.timestamp,
+      ts_epoch_ms: m.ts_epoch_ms,
+      type: m.type,
+      text: m.text,
+      reactions: m.reactions,
+      attachments: m.attachments,
+      reply_to_message_id: m.reply_to_message_id,
+      is_deleted: m.is_deleted,
+    }));
+  },
+});

--- a/convex/beeper/queries/getRecentChats.test.ts
+++ b/convex/beeper/queries/getRecentChats.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+
+describe("getRecentChats projection", () => {
+  test("strips raw + participants from the row to keep payload small", () => {
+    const c = {
+      _id: "id_1",
+      chat_id: "!room:beeper.local",
+      title: "auf family",
+      type: "group",
+      network: "WhatsApp",
+      participant_count: 41,
+      last_activity: "2026-05-22T22:26:41.000Z",
+      unread_count: 1,
+      message_count: 4321,
+      raw: "{...large blob...}",
+      participants: new Array(41).fill({}),
+    };
+    const projected = {
+      _id: c._id,
+      chat_id: c.chat_id,
+      title: c.title,
+      type: c.type,
+      network: c.network,
+      participant_count: c.participant_count,
+      last_activity: c.last_activity,
+      unread_count: c.unread_count,
+      message_count: c.message_count,
+    };
+    expect("raw" in projected).toBe(false);
+    expect("participants" in projected).toBe(false);
+    expect(projected.participant_count).toBe(41);
+  });
+
+  test("default limit is 50", () => {
+    const limit = undefined as number | undefined;
+    expect(limit ?? 50).toBe(50);
+  });
+});

--- a/convex/beeper/queries/getRecentChats.ts
+++ b/convex/beeper/queries/getRecentChats.ts
@@ -1,0 +1,45 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+
+/**
+ * Most-recently-active chats, optionally filtered to a single network.
+ *
+ * Backed by the `by_network_activity` / `by_last_activity` indexes so the
+ * usual "show me my recent chats" panel is a single index walk.
+ */
+export const getRecentChats = query({
+  args: {
+    network: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 50;
+
+    const rows = args.network
+      ? await ctx.db
+          .query("beeper_chats")
+          .withIndex("by_network_activity", (q) =>
+            q.eq("network", args.network!),
+          )
+          .order("desc")
+          .take(limit)
+      : await ctx.db
+          .query("beeper_chats")
+          .withIndex("by_last_activity")
+          .order("desc")
+          .take(limit);
+
+    return rows.map((c) => ({
+      _id: c._id,
+      chat_id: c.chat_id,
+      title: c.title,
+      type: c.type,
+      network: c.network,
+      participant_count: c.participant_count,
+      last_activity: c.last_activity,
+      unread_count: c.unread_count,
+      message_count: c.message_count,
+    }));
+  },
+});

--- a/convex/beeper/queries/getSyncStatus.test.ts
+++ b/convex/beeper/queries/getSyncStatus.test.ts
@@ -1,46 +1,45 @@
 import { describe, expect, test } from "vitest";
 
 describe("getSyncStatus aggregation", () => {
-  test("aggregates per-account chat and message counts", () => {
+  test("sums per-account chat counts and rolls up message_count from beeper_chats", () => {
     const accounts = [
       { account_id: "whatsapp", network: "WhatsApp" },
       { account_id: "telegram", network: "Telegram" },
     ];
     const chats = [
-      { account_id: "whatsapp" },
-      { account_id: "whatsapp" },
-      { account_id: "telegram" },
-    ];
-    const messages = [
-      { account_id: "whatsapp" },
-      { account_id: "whatsapp" },
-      { account_id: "whatsapp" },
-      { account_id: "telegram" },
+      { account_id: "whatsapp", message_count: 100 },
+      { account_id: "whatsapp", message_count: 50 },
+      { account_id: "telegram", message_count: 25 },
     ];
 
-    const status = accounts.map((a) => ({
-      account_id: a.account_id,
-      chat_count: chats.filter((c) => c.account_id === a.account_id).length,
-      message_count: messages.filter((m) => m.account_id === a.account_id)
-        .length,
-    }));
+    const status = accounts.map((a) => {
+      const ac = chats.filter((c) => c.account_id === a.account_id);
+      return {
+        account_id: a.account_id,
+        chat_count: ac.length,
+        message_count: ac.reduce((s, c) => s + (c.message_count ?? 0), 0),
+      };
+    });
 
     expect(status[0]).toEqual({
       account_id: "whatsapp",
       chat_count: 2,
-      message_count: 3,
+      message_count: 150,
     });
     expect(status[1]).toEqual({
       account_id: "telegram",
       chat_count: 1,
-      message_count: 1,
+      message_count: 25,
     });
   });
 
-  test("empty deployment returns zero totals", () => {
-    const chats: unknown[] = [];
-    const messages: unknown[] = [];
-    expect(chats.length).toBe(0);
-    expect(messages.length).toBe(0);
+  test("missing message_count is treated as zero", () => {
+    const chats: { account_id: string; message_count?: number }[] = [
+      { account_id: "whatsapp", message_count: 10 },
+      { account_id: "whatsapp" },
+      { account_id: "whatsapp", message_count: 5 },
+    ];
+    const total = chats.reduce((s, c) => s + (c.message_count ?? 0), 0);
+    expect(total).toBe(15);
   });
 });

--- a/convex/beeper/queries/getSyncStatus.test.ts
+++ b/convex/beeper/queries/getSyncStatus.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+describe("getSyncStatus aggregation", () => {
+  test("aggregates per-account chat and message counts", () => {
+    const accounts = [
+      { account_id: "whatsapp", network: "WhatsApp" },
+      { account_id: "telegram", network: "Telegram" },
+    ];
+    const chats = [
+      { account_id: "whatsapp" },
+      { account_id: "whatsapp" },
+      { account_id: "telegram" },
+    ];
+    const messages = [
+      { account_id: "whatsapp" },
+      { account_id: "whatsapp" },
+      { account_id: "whatsapp" },
+      { account_id: "telegram" },
+    ];
+
+    const status = accounts.map((a) => ({
+      account_id: a.account_id,
+      chat_count: chats.filter((c) => c.account_id === a.account_id).length,
+      message_count: messages.filter((m) => m.account_id === a.account_id)
+        .length,
+    }));
+
+    expect(status[0]).toEqual({
+      account_id: "whatsapp",
+      chat_count: 2,
+      message_count: 3,
+    });
+    expect(status[1]).toEqual({
+      account_id: "telegram",
+      chat_count: 1,
+      message_count: 1,
+    });
+  });
+
+  test("empty deployment returns zero totals", () => {
+    const chats: unknown[] = [];
+    const messages: unknown[] = [];
+    expect(chats.length).toBe(0);
+    expect(messages.length).toBe(0);
+  });
+});

--- a/convex/beeper/queries/getSyncStatus.ts
+++ b/convex/beeper/queries/getSyncStatus.ts
@@ -1,0 +1,35 @@
+import { query } from "../../_generated/server";
+
+/**
+ * Aggregate Beeper sync health across accounts. Returns one entry per known
+ * account plus rolled-up counts for the dashboard's sync widget.
+ */
+export const getSyncStatus = query({
+  handler: async (ctx) => {
+    const accounts = await ctx.db.query("beeper_accounts").collect();
+    const chats = await ctx.db.query("beeper_chats").collect();
+    const messages = await ctx.db.query("beeper_messages").collect();
+
+    const accountStatus = accounts.map((a) => {
+      const accountChats = chats.filter((c) => c.account_id === a.account_id);
+      const accountMessages = messages.filter(
+        (m) => m.account_id === a.account_id,
+      );
+      return {
+        account_id: a.account_id,
+        network: a.network,
+        is_active: a.is_active,
+        chat_count: accountChats.length,
+        message_count: accountMessages.length,
+        last_full_sync_at: a.last_full_sync_at,
+        last_incremental_sync_at: a.last_incremental_sync_at,
+      };
+    });
+
+    return {
+      accounts: accountStatus,
+      total_chats: chats.length,
+      total_messages: messages.length,
+    };
+  },
+});

--- a/convex/beeper/queries/getSyncStatus.ts
+++ b/convex/beeper/queries/getSyncStatus.ts
@@ -1,35 +1,46 @@
 import { query } from "../../_generated/server";
 
 /**
- * Aggregate Beeper sync health across accounts. Returns one entry per known
- * account plus rolled-up counts for the dashboard's sync widget.
+ * Aggregate Beeper sync health across accounts. One row per known account
+ * plus rolled-up totals for dashboards.
+ *
+ * Avoids materialising the full messages table (would exceed Convex's 16 MB
+ * per-query read limit at ~20k messages × multi-KB raw JSON). Instead, the
+ * per-chat `message_count` cache is summed up from `beeper_chats`, which is
+ * cheap because that table has one row per chat (hundreds, not tens of
+ * thousands).
  */
 export const getSyncStatus = query({
   handler: async (ctx) => {
     const accounts = await ctx.db.query("beeper_accounts").collect();
     const chats = await ctx.db.query("beeper_chats").collect();
-    const messages = await ctx.db.query("beeper_messages").collect();
 
     const accountStatus = accounts.map((a) => {
       const accountChats = chats.filter((c) => c.account_id === a.account_id);
-      const accountMessages = messages.filter(
-        (m) => m.account_id === a.account_id,
+      const messageCount = accountChats.reduce(
+        (sum, c) => sum + (c.message_count ?? 0),
+        0,
       );
       return {
         account_id: a.account_id,
         network: a.network,
         is_active: a.is_active,
         chat_count: accountChats.length,
-        message_count: accountMessages.length,
+        message_count: messageCount,
         last_full_sync_at: a.last_full_sync_at,
         last_incremental_sync_at: a.last_incremental_sync_at,
       };
     });
 
+    const totalMessages = chats.reduce(
+      (sum, c) => sum + (c.message_count ?? 0),
+      0,
+    );
+
     return {
       accounts: accountStatus,
       total_chats: chats.length,
-      total_messages: messages.length,
+      total_messages: totalMessages,
     };
   },
 });

--- a/convex/beeper/queries/searchMessages.test.ts
+++ b/convex/beeper/queries/searchMessages.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+
+describe("searchMessages projection", () => {
+  test("shape mirrors result projection (id, chat, network, sender, ...)", () => {
+    const m = {
+      _id: "id_1",
+      chat_id: "!room:beeper.local",
+      message_id: "100",
+      network: "WhatsApp",
+      sender_name: "Susan",
+      timestamp: "2026-05-22T22:00:00.000Z",
+      type: "TEXT",
+      text: "hello world",
+      is_sender: false,
+      attachments: [],
+    };
+    const projected = {
+      _id: m._id,
+      chat_id: m.chat_id,
+      message_id: m.message_id,
+      network: m.network,
+      sender_name: m.sender_name,
+      timestamp: m.timestamp,
+      type: m.type,
+      text: m.text,
+      is_sender: m.is_sender,
+      has_attachments: (m.attachments?.length ?? 0) > 0,
+    };
+    expect(projected.has_attachments).toBe(false);
+    expect(projected.text).toBe("hello world");
+  });
+
+  test("default limit is 50", () => {
+    const limit = undefined as number | undefined;
+    expect(limit ?? 50).toBe(50);
+  });
+});

--- a/convex/beeper/queries/searchMessages.ts
+++ b/convex/beeper/queries/searchMessages.ts
@@ -1,0 +1,47 @@
+import { v } from "convex/values";
+
+import { query } from "../../_generated/server";
+
+/**
+ * Full-text search across all Beeper messages.
+ *
+ * Backed by the `search_text` Convex search index on `beeper_messages.text`.
+ * Filters by network / chat_id / sender_id are pushed into the index when
+ * provided.
+ */
+export const searchMessages = query({
+  args: {
+    query: v.string(),
+    network: v.optional(v.string()),
+    chat_id: v.optional(v.string()),
+    sender_id: v.optional(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 50;
+
+    const results = await ctx.db
+      .query("beeper_messages")
+      .withSearchIndex("search_text", (q) => {
+        let qq = q.search("text", args.query);
+        if (args.network) qq = qq.eq("network", args.network);
+        if (args.chat_id) qq = qq.eq("chat_id", args.chat_id);
+        if (args.sender_id) qq = qq.eq("sender_id", args.sender_id);
+        return qq;
+      })
+      .take(limit);
+
+    return results.map((m) => ({
+      _id: m._id,
+      chat_id: m.chat_id,
+      message_id: m.message_id,
+      network: m.network,
+      sender_name: m.sender_name,
+      timestamp: m.timestamp,
+      type: m.type,
+      text: m.text,
+      is_sender: m.is_sender,
+      has_attachments: (m.attachments?.length ?? 0) > 0,
+    }));
+  },
+});

--- a/convex/beeper/sync/auth.ts
+++ b/convex/beeper/sync/auth.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared bearer-secret check used by every /beeper/* HTTP route.
+ *
+ * Returns null on success, or a Response (401/500) on failure that the
+ * handler should return as-is.
+ */
+export function checkBeeperIngestAuth(req: Request): Response | null {
+  const expectedSecret = process.env.BEEPER_INGEST_SECRET;
+  if (!expectedSecret) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: "BEEPER_INGEST_SECRET is not configured on the Convex deployment",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  const authHeader = req.headers.get("authorization") ?? "";
+  const provided = authHeader.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length)
+    : "";
+  if (provided !== expectedSecret) {
+    return new Response(
+      JSON.stringify({ ok: false, error: "unauthorized" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  return null;
+}
+
+export function jsonResponse(
+  body: unknown,
+  status = 200,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/convex/beeper/sync/handleAttachments.ts
+++ b/convex/beeper/sync/handleAttachments.ts
@@ -1,0 +1,96 @@
+import { internal } from "../../_generated/api";
+import { httpAction } from "../../_generated/server";
+
+import { checkBeeperIngestAuth, jsonResponse } from "./auth";
+
+/**
+ * POST /beeper/attachments/discover
+ *
+ * Body: { mxc_ids: string[] }
+ * Returns: { ok: true, uploaded: {mxc_id, convex_storage_id}[], missing: string[] }
+ *
+ * Called by the local uploader at the start of every run (and per batch) to
+ * skip files we've already uploaded — making re-runs effectively free.
+ */
+export const handleDiscover = httpAction(async (ctx, req) => {
+  const authErr = checkBeeperIngestAuth(req);
+  if (authErr) return authErr;
+
+  let body: { mxc_ids?: unknown };
+  try {
+    body = (await req.json()) as { mxc_ids?: unknown };
+  } catch {
+    return jsonResponse({ ok: false, error: "invalid JSON" }, 400);
+  }
+  if (!Array.isArray(body.mxc_ids) || !body.mxc_ids.every((x) => typeof x === "string")) {
+    return jsonResponse({ ok: false, error: "mxc_ids must be string[]" }, 400);
+  }
+
+  const result = await ctx.runQuery(
+    internal.beeper.queries.discoverAttachments.discoverAttachments,
+    { mxc_ids: body.mxc_ids as string[] },
+  );
+  return jsonResponse({ ok: true, ...result });
+});
+
+/**
+ * POST /beeper/attachments/uploadUrl
+ *
+ * Body: {}
+ * Returns: { ok: true, uploadUrl: string }
+ *
+ * The uploader PUTs the file bytes to that URL; Convex responds with
+ * { storageId: string } which the uploader passes to /record.
+ */
+export const handleUploadUrl = httpAction(async (ctx, req) => {
+  const authErr = checkBeeperIngestAuth(req);
+  if (authErr) return authErr;
+
+  const uploadUrl = await ctx.runMutation(
+    internal.beeper.internalMutations.generateUploadUrl.generateUploadUrl,
+  );
+  return jsonResponse({ ok: true, uploadUrl });
+});
+
+/**
+ * POST /beeper/attachments/record
+ *
+ * Body: { mxc_id, convex_storage_id, network, mime_type?, file_name?,
+ *         file_size?, width?, height?, duration_ms? }
+ * Returns: { ok: true }
+ *
+ * Idempotent: a race where two uploaders write the same mxc_id results in
+ * the second-arriver's storage object being deleted by the mutation.
+ */
+export const handleRecord = httpAction(async (ctx, req) => {
+  const authErr = checkBeeperIngestAuth(req);
+  if (authErr) return authErr;
+
+  let body: AttachmentRecordIn;
+  try {
+    body = (await req.json()) as AttachmentRecordIn;
+  } catch {
+    return jsonResponse({ ok: false, error: "invalid JSON" }, 400);
+  }
+  if (typeof body.mxc_id !== "string" || typeof body.convex_storage_id !== "string") {
+    return jsonResponse({ ok: false, error: "mxc_id and convex_storage_id required" }, 400);
+  }
+
+  await ctx.runMutation(
+    internal.beeper.internalMutations.recordAttachment.recordAttachment,
+    body,
+  );
+  return jsonResponse({ ok: true });
+});
+
+type AttachmentRecordIn = {
+  mxc_id: string;
+  convex_storage_id: string;
+  network: string;
+  mime_type?: string;
+  file_name?: string;
+  file_size?: number;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+};

--- a/convex/beeper/sync/handleIngest.ts
+++ b/convex/beeper/sync/handleIngest.ts
@@ -1,0 +1,190 @@
+import { internal } from "../../_generated/api";
+import { httpAction } from "../../_generated/server";
+
+/**
+ * Ingest endpoint for the Beeper local sync script.
+ *
+ * Path:    POST /beeper/ingest
+ * Headers: Authorization: Bearer <BEEPER_INGEST_SECRET>
+ *
+ * Body (any combination):
+ *   {
+ *     "accounts"?: BeeperAccount[],
+ *     "chats"?: BeeperChat[],
+ *     "messages_by_chat"?: { chat_id: string, messages: BeeperMessage[] }[],
+ *     "mark_synced"?: { account_id: string, sync_type: "full" | "incremental" }
+ *   }
+ *
+ * The endpoint is intentionally batch-shaped: the script collects a few
+ * thousand rows per request rather than one row per HTTP call. Messages are
+ * grouped by chat because upsertMessages enforces per-chat batching.
+ *
+ * Response: { ok: true, counts: { accounts, chats, messages } }
+ */
+export const handleIngest = httpAction(async (ctx, req) => {
+  const expectedSecret = process.env.BEEPER_INGEST_SECRET;
+  if (!expectedSecret) {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: "BEEPER_INGEST_SECRET is not configured on the Convex deployment",
+      }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const authHeader = req.headers.get("authorization") ?? "";
+  const provided = authHeader.startsWith("Bearer ")
+    ? authHeader.slice("Bearer ".length)
+    : "";
+  if (provided !== expectedSecret) {
+    return new Response(
+      JSON.stringify({ ok: false, error: "unauthorized" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  let body: IngestBody;
+  try {
+    body = (await req.json()) as IngestBody;
+  } catch {
+    return new Response(
+      JSON.stringify({ ok: false, error: "invalid JSON body" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const counts = { accounts: 0, chats: 0, messages: 0 };
+
+  if (body.accounts) {
+    for (const account of body.accounts) {
+      await ctx.runMutation(
+        internal.beeper.internalMutations.upsertAccount.upsertAccount,
+        {
+          account,
+          mark_full_sync_started: body.mark_full_sync_started ?? false,
+        },
+      );
+      counts.accounts += 1;
+    }
+  }
+
+  if (body.chats) {
+    for (const chat of body.chats) {
+      await ctx.runMutation(
+        internal.beeper.internalMutations.upsertChat.upsertChat,
+        { chat },
+      );
+      counts.chats += 1;
+    }
+  }
+
+  if (body.messages_by_chat) {
+    for (const group of body.messages_by_chat) {
+      const result = await ctx.runMutation(
+        internal.beeper.internalMutations.upsertMessages.upsertMessages,
+        { chat_id: group.chat_id, messages: group.messages },
+      );
+      counts.messages += result.inserted + result.updated;
+    }
+  }
+
+  if (body.mark_synced) {
+    await ctx.runMutation(
+      internal.beeper.internalMutations.markAccountSynced.markAccountSynced,
+      body.mark_synced,
+    );
+  }
+
+  return new Response(JSON.stringify({ ok: true, counts }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+});
+
+// Loose types for the ingest payload. The strict per-row validators live in
+// the internal mutations themselves; this handler is intentionally permissive
+// so a bad row gets a typed runtime error from Convex, not a 400 here.
+type IngestBody = {
+  accounts?: BeeperAccountIn[];
+  chats?: BeeperChatIn[];
+  messages_by_chat?: { chat_id: string; messages: BeeperMessageIn[] }[];
+  mark_full_sync_started?: boolean;
+  mark_synced?: { account_id: string; sync_type: "full" | "incremental" };
+};
+
+// These mirror the validators in types/ingestApi.ts but as plain TS types so
+// the handler compiles without re-exporting Infer<> values.
+type BeeperAccountIn = {
+  account_id: string;
+  network: string;
+  display_name?: string;
+  phone_number?: string;
+  is_active?: boolean;
+  raw?: string;
+};
+
+type Participant = {
+  id: string;
+  phone_number?: string;
+  full_name?: string;
+  is_self?: boolean;
+  is_admin?: boolean;
+  img_url?: string;
+};
+
+type BeeperChatIn = {
+  account_id: string;
+  network: string;
+  chat_id: string;
+  local_chat_id?: string;
+  title?: string;
+  description?: string;
+  type: string;
+  img_url?: string;
+  participants: Participant[];
+  last_activity?: string;
+  is_archived?: boolean;
+  is_muted?: boolean;
+  is_pinned?: boolean;
+  is_read_only?: boolean;
+  unread_count?: number;
+  raw?: string;
+};
+
+type Reaction = { participant_id: string; emoji_or_key: string };
+
+type AttachmentIn = {
+  mxc_id: string;
+  type?: string;
+  mime_type?: string;
+  file_name?: string;
+  file_size?: number;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+  is_gif?: boolean;
+  is_sticker?: boolean;
+  beeper_src_url?: string;
+  convex_storage_id?: string;
+};
+
+type BeeperMessageIn = {
+  account_id: string;
+  network: string;
+  chat_id: string;
+  message_id: string;
+  sort_key?: string;
+  sender_id?: string;
+  sender_name?: string;
+  is_sender?: boolean;
+  timestamp?: string;
+  type?: string;
+  text?: string;
+  reactions?: Reaction[];
+  attachments?: AttachmentIn[];
+  reply_to_message_id?: string;
+  is_deleted?: boolean;
+  is_hidden?: boolean;
+  raw?: string;
+};

--- a/convex/beeper/sync/handleIngest.ts
+++ b/convex/beeper/sync/handleIngest.ts
@@ -1,6 +1,8 @@
 import { internal } from "../../_generated/api";
 import { httpAction } from "../../_generated/server";
 
+import { checkBeeperIngestAuth, jsonResponse } from "./auth";
+
 /**
  * Ingest endpoint for the Beeper local sync script.
  *
@@ -22,36 +24,14 @@ import { httpAction } from "../../_generated/server";
  * Response: { ok: true, counts: { accounts, chats, messages } }
  */
 export const handleIngest = httpAction(async (ctx, req) => {
-  const expectedSecret = process.env.BEEPER_INGEST_SECRET;
-  if (!expectedSecret) {
-    return new Response(
-      JSON.stringify({
-        ok: false,
-        error: "BEEPER_INGEST_SECRET is not configured on the Convex deployment",
-      }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
-  }
-
-  const authHeader = req.headers.get("authorization") ?? "";
-  const provided = authHeader.startsWith("Bearer ")
-    ? authHeader.slice("Bearer ".length)
-    : "";
-  if (provided !== expectedSecret) {
-    return new Response(
-      JSON.stringify({ ok: false, error: "unauthorized" }),
-      { status: 401, headers: { "Content-Type": "application/json" } },
-    );
-  }
+  const authErr = checkBeeperIngestAuth(req);
+  if (authErr) return authErr;
 
   let body: IngestBody;
   try {
     body = (await req.json()) as IngestBody;
   } catch {
-    return new Response(
-      JSON.stringify({ ok: false, error: "invalid JSON body" }),
-      { status: 400, headers: { "Content-Type": "application/json" } },
-    );
+    return jsonResponse({ ok: false, error: "invalid JSON body" }, 400);
   }
 
   const counts = { accounts: 0, chats: 0, messages: 0 };
@@ -96,10 +76,7 @@ export const handleIngest = httpAction(async (ctx, req) => {
     );
   }
 
-  return new Response(JSON.stringify({ ok: true, counts }), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-  });
+  return jsonResponse({ ok: true, counts });
 });
 
 // Loose types for the ingest payload. The strict per-row validators live in

--- a/convex/beeper/types/ingestApi.ts
+++ b/convex/beeper/types/ingestApi.ts
@@ -1,0 +1,97 @@
+import { v } from "convex/values";
+
+/**
+ * Validators for payloads coming in over the /beeper/ingest HTTP route.
+ *
+ * Source-of-truth is the Beeper Desktop local HTTP API (http://localhost:23373/v1).
+ * The local sync script reshapes Beeper's camelCase responses into the
+ * snake_case payloads defined here before POSTing them to Convex.
+ *
+ * We accept v.any() for raw blobs (the original Beeper objects). They are
+ * stored as JSON.stringify on the row so we can re-derive structured fields
+ * later without re-pulling from Beeper.
+ */
+
+export const ingestAccountSchema = v.object({
+  account_id: v.string(),
+  network: v.string(),
+  display_name: v.optional(v.string()),
+  phone_number: v.optional(v.string()),
+  is_active: v.optional(v.boolean()),
+  raw: v.optional(v.string()),
+});
+
+const participantSchema = v.object({
+  id: v.string(),
+  phone_number: v.optional(v.string()),
+  full_name: v.optional(v.string()),
+  is_self: v.optional(v.boolean()),
+  is_admin: v.optional(v.boolean()),
+  img_url: v.optional(v.string()),
+});
+
+export const ingestChatSchema = v.object({
+  account_id: v.string(),
+  network: v.string(),
+  chat_id: v.string(),
+  local_chat_id: v.optional(v.string()),
+  title: v.optional(v.string()),
+  description: v.optional(v.string()),
+  type: v.string(),
+  img_url: v.optional(v.string()),
+  participants: v.array(participantSchema),
+  last_activity: v.optional(v.string()),
+  is_archived: v.optional(v.boolean()),
+  is_muted: v.optional(v.boolean()),
+  is_pinned: v.optional(v.boolean()),
+  is_read_only: v.optional(v.boolean()),
+  unread_count: v.optional(v.number()),
+  raw: v.optional(v.string()),
+});
+
+const reactionSchema = v.object({
+  participant_id: v.string(),
+  emoji_or_key: v.string(),
+});
+
+const attachmentSchema = v.object({
+  mxc_id: v.string(),
+  type: v.optional(v.string()),
+  mime_type: v.optional(v.string()),
+  file_name: v.optional(v.string()),
+  file_size: v.optional(v.number()),
+  width: v.optional(v.number()),
+  height: v.optional(v.number()),
+  duration_ms: v.optional(v.number()),
+  is_gif: v.optional(v.boolean()),
+  is_sticker: v.optional(v.boolean()),
+  beeper_src_url: v.optional(v.string()),
+  convex_storage_id: v.optional(v.string()),
+});
+
+export const ingestMessageSchema = v.object({
+  account_id: v.string(),
+  network: v.string(),
+  chat_id: v.string(),
+
+  message_id: v.string(),
+  sort_key: v.optional(v.string()),
+
+  sender_id: v.optional(v.string()),
+  sender_name: v.optional(v.string()),
+  is_sender: v.optional(v.boolean()),
+
+  timestamp: v.optional(v.string()),
+
+  type: v.optional(v.string()),
+  text: v.optional(v.string()),
+
+  reactions: v.optional(v.array(reactionSchema)),
+  attachments: v.optional(v.array(attachmentSchema)),
+
+  reply_to_message_id: v.optional(v.string()),
+  is_deleted: v.optional(v.boolean()),
+  is_hidden: v.optional(v.boolean()),
+
+  raw: v.optional(v.string()),
+});

--- a/convex/dashboard/queries/getDashboardStats.test.ts
+++ b/convex/dashboard/queries/getDashboardStats.test.ts
@@ -56,6 +56,18 @@ function makeRoutine(overrides: Partial<{
   };
 }
 
+function makeMetadata(overrides: Partial<{
+  project_id: string;
+  priority: number | undefined;
+  scheduled_date: string | undefined;
+}>): AnyDoc {
+  return {
+    project_id: overrides.project_id ?? "p1",
+    priority: overrides.priority,
+    scheduled_date: overrides.scheduled_date,
+  };
+}
+
 describe("computeDayBoundariesISO", () => {
   test("returns YYYY-MM-DD for today and today + 7 in UTC", () => {
     // Fixed instant: 2026-05-15 10:00 UTC. timezone offset 0.
@@ -109,12 +121,14 @@ describe("aggregateDashboardStats", () => {
     items: AnyDoc[];
     projects: AnyDoc[];
     routines: AnyDoc[];
+    projectMetadata: AnyDoc[];
     overdueRoutineTaskCount: number;
   }> = {}): DashboardStats {
     return aggregateDashboardStats({
       items: overrides.items ?? [],
       projects: overrides.projects ?? [],
       routines: overrides.routines ?? [],
+      projectMetadata: overrides.projectMetadata ?? [],
       overdueRoutineTaskCount: overrides.overdueRoutineTaskCount ?? 0,
       todayISO: today,
       sevenDaysISO: sevenDays,
@@ -131,7 +145,7 @@ describe("aggregateDashboardStats", () => {
     expect(stats.p1Active).toBe(0);
     expect(stats.priorityCounts).toEqual({ p1: 0, p2: 0, p3: 0, p4: 0, total: 0 });
     expect(stats.topProjects).toEqual([]);
-    expect(stats.todayQueue).toEqual([]);
+    expect(stats.focusQueue).toEqual([]);
     expect(stats.routines).toEqual({
       active: 0,
       paused: 0,
@@ -200,44 +214,193 @@ describe("aggregateDashboardStats", () => {
     });
     expect(stats.inbox).toBe(2);
     expect(stats.topProjects).toEqual([
-      { todoistId: "auf", name: "AUF", color: "grey", activeTaskCount: 3 },
-      { todoistId: "health", name: "Health", color: "grey", activeTaskCount: 1 },
+      {
+        todoistId: "auf",
+        name: "AUF",
+        color: "grey",
+        activeTaskCount: 3,
+        priority: null,
+        scheduledDate: null,
+      },
+      {
+        todoistId: "health",
+        name: "Health",
+        color: "grey",
+        activeTaskCount: 1,
+        priority: null,
+        scheduledDate: null,
+      },
     ]);
   });
 
-  test("today queue is ordered by start time, timed items first", () => {
+  test("top projects ranks by priority then by active count", () => {
+    const projects = [
+      makeProject({ todoist_id: "auf", name: "AUF" }),
+      makeProject({ todoist_id: "health", name: "Health" }),
+      makeProject({ todoist_id: "home", name: "Home" }),
+    ];
     const stats = build({
+      projects,
+      // Active counts: health=5, auf=3, home=1. But priority should override.
       items: [
+        makeItem({ project_id: "health" }),
+        makeItem({ project_id: "health" }),
+        makeItem({ project_id: "health" }),
+        makeItem({ project_id: "health" }),
+        makeItem({ project_id: "health" }),
+        makeItem({ project_id: "auf" }),
+        makeItem({ project_id: "auf" }),
+        makeItem({ project_id: "auf" }),
+        makeItem({ project_id: "home" }),
+      ],
+      projectMetadata: [
+        makeMetadata({ project_id: "auf", priority: 4 }), // P1
+        makeMetadata({ project_id: "home", priority: 3 }), // P2
+        // health has no priority metadata
+      ],
+    });
+    expect(stats.topProjects.map((p) => p.todoistId)).toEqual([
+      "auf", // P1, count 3
+      "home", // P2, count 1
+      "health", // null, count 5 (loses to priority-set projects)
+    ]);
+    expect(stats.topProjects[0].priority).toBe(4);
+  });
+
+  test("focus queue ranks by priority desc, then dueness (overdue > today > future)", () => {
+    const projects = [
+      makeProject({ todoist_id: "auf", name: "AUF", color: "lavender" }),
+    ];
+    const stats = build({
+      projects,
+      items: [
+        // P4 due today (low priority)
         makeItem({
-          todoist_id: "afternoon",
-          content: "Afternoon",
-          due: { date: today, datetime: `${today}T14:00:00Z` },
-        }),
-        makeItem({
-          todoist_id: "untimed-z",
-          content: "Z untimed",
+          todoist_id: "p4-today",
+          content: "P4 today",
+          priority: 1,
+          project_id: "auf",
           due: { date: today },
         }),
+        // P1 future (high priority)
         makeItem({
-          todoist_id: "morning",
-          content: "Morning",
-          due: { date: today, datetime: `${today}T09:00:00Z` },
+          todoist_id: "p1-future",
+          content: "P1 future",
+          priority: 4,
+          project_id: "auf",
+          due: { date: "2026-12-01" },
         }),
+        // P1 overdue (high priority, urgent)
         makeItem({
-          todoist_id: "untimed-a",
-          content: "A untimed",
+          todoist_id: "p1-overdue",
+          content: "P1 overdue",
+          priority: 4,
+          project_id: "auf",
+          due: { date: "2026-05-01" },
+        }),
+        // P2 today
+        makeItem({
+          todoist_id: "p2-today",
+          content: "P2 today",
+          priority: 3,
+          project_id: "auf",
           due: { date: today },
+        }),
+        // P1 no date
+        makeItem({
+          todoist_id: "p1-nodate",
+          content: "P1 nodate",
+          priority: 4,
+          project_id: "auf",
         }),
       ],
     });
-    expect(stats.todayQueue.map((q) => q.todoistId)).toEqual([
-      "morning",
-      "afternoon",
-      "untimed-a",
-      "untimed-z",
+    // Expected order: all P1 first (overdue > future > nodate within P1), then P2, then P4.
+    expect(stats.focusQueue.map((f) => f.todoistId)).toEqual([
+      "p1-overdue",
+      "p1-future",
+      "p1-nodate",
+      "p2-today",
+      "p4-today",
     ]);
-    expect(stats.todayQueue[0].startTime).toBe("09:00");
-    expect(stats.todayQueue[2].startTime).toBeNull();
+    expect(stats.focusQueue[0].isOverdue).toBe(true);
+    expect(stats.focusQueue[0].projectName).toBe("AUF");
+    expect(stats.focusQueue[0].projectColor).toBe("lavender");
+  });
+
+  test("strips master-db metadata tasks (content starts with *) from all counts", () => {
+    const projects = [
+      makeProject({ todoist_id: "auf", name: "AUF", inbox_project: false }),
+    ];
+    const stats = build({
+      projects,
+      items: [
+        // Real tasks
+        makeItem({
+          todoist_id: "real-1",
+          content: "Real task",
+          priority: 4,
+          project_id: "auf",
+          due: { date: today },
+        }),
+        makeItem({
+          todoist_id: "real-2",
+          content: "Another real task",
+          priority: 1,
+          project_id: "auf",
+        }),
+        // Master-db metadata tasks (start with *)
+        makeItem({
+          todoist_id: "meta-1",
+          content: "* P1",
+          priority: 4,
+          project_id: "auf",
+          due: { date: today },
+        }),
+        makeItem({
+          todoist_id: "meta-2",
+          content: "* AUF",
+          priority: 4,
+          project_id: "auf",
+        }),
+      ],
+    });
+    // 2 real items, not 4
+    expect(stats.priorityCounts.total).toBe(2);
+    expect(stats.p1Active).toBe(1); // only "real-1" is P1, not "meta-1"
+    expect(stats.dueToday).toBe(1); // only "real-1" due today
+    expect(stats.topProjects[0].activeTaskCount).toBe(2);
+    expect(stats.focusQueue.map((f) => f.todoistId)).toEqual([
+      "real-1",
+      "real-2",
+    ]);
+  });
+
+  test("focus queue excludes inbox tasks", () => {
+    const projects = [
+      makeProject({
+        todoist_id: "inbox",
+        name: "Inbox",
+        inbox_project: true,
+      }),
+      makeProject({ todoist_id: "auf", name: "AUF" }),
+    ];
+    const stats = build({
+      projects,
+      items: [
+        makeItem({
+          todoist_id: "inbox-p1",
+          priority: 4,
+          project_id: "inbox",
+        }),
+        makeItem({
+          todoist_id: "auf-p4",
+          priority: 1,
+          project_id: "auf",
+        }),
+      ],
+    });
+    expect(stats.focusQueue.map((f) => f.todoistId)).toEqual(["auf-p4"]);
   });
 
   test("routine summary averages only non-null completion rates", () => {

--- a/convex/dashboard/queries/getDashboardStats.ts
+++ b/convex/dashboard/queries/getDashboardStats.ts
@@ -12,15 +12,20 @@ import { query } from "../../_generated/server";
 export interface DashboardTopProject {
   todoistId: string;
   name: string;
-  color: string;
+  color: string; // Todoist color name (e.g., "lavender")
   activeTaskCount: number;
+  priority: number | null; // Project metadata priority: 4 = P1 (highest), null if unset
+  scheduledDate: string | null; // YYYY-MM-DD from project metadata, when the project itself is scheduled
 }
 
-export interface DashboardTodayQueueItem {
+export interface DashboardFocusItem {
   todoistId: string;
   content: string;
   priority: number; // Todoist API priority: 4 = P1 (highest)
-  startTime: string | null; // "HH:MM" if the due has a datetime; null for all-day
+  projectName: string | null;
+  projectColor: string | null; // Todoist color name
+  dueDate: string | null; // YYYY-MM-DD if scheduled; null otherwise
+  isOverdue: boolean;
 }
 
 export interface DashboardPriorityCounts {
@@ -50,7 +55,7 @@ export interface DashboardStats {
   routines: DashboardRoutinesSummary;
   // Row 3
   topProjects: DashboardTopProject[];
-  todayQueue: DashboardTodayQueueItem[];
+  focusQueue: DashboardFocusItem[];
   // Metadata
   generatedAt: number;
 }
@@ -104,20 +109,34 @@ export function aggregateDashboardStats(input: {
   items: Doc<"todoist_items">[];
   projects: Doc<"todoist_projects">[];
   routines: Doc<"routines">[];
+  projectMetadata: Doc<"todoist_project_metadata">[];
   overdueRoutineTaskCount: number;
   todayISO: string;
   sevenDaysISO: string;
   nowMs: number;
 }): DashboardStats {
   const {
-    items,
+    items: rawItems,
     projects,
     routines,
+    projectMetadata,
     overdueRoutineTaskCount,
     todayISO,
     sevenDaysISO,
     nowMs,
   } = input;
+
+  // Strip out master-db's internal metadata tasks (content starts with "*").
+  // These special tasks encode per-project priority/scheduled-date and aren't
+  // real to-do items — including them would inflate every count on the
+  // dashboard. The same filter is used by
+  // convex/todoist/computed/mutations/extractProjectMetadata.ts.
+  const items = rawItems.filter((item) => !item.content.startsWith("*"));
+
+  // Project metadata lookup, keyed by todoist project id.
+  const metadataByProject = new Map(
+    projectMetadata.map((m) => [m.project_id, m])
+  );
 
   // Match the canonical fallback in
   // convex/todoist/computed/queries/getAllListCounts.ts: the `inbox_project`
@@ -186,50 +205,85 @@ export function aggregateDashboardStats(input: {
     }
   }
 
-  // Top projects: sort by active task count descending, take top 6, attach
-  // display fields.
+  // Top projects: rank by (priority desc, active task count desc). Projects
+  // without a metadata priority sort below all priority-set projects. Take
+  // top 6 and enrich with display fields. Only include projects that exist
+  // in the active project set; tasks pointing at archived/deleted projects
+  // are dropped from this card.
   const projectsByTodoistId = new Map(
     projects.map((p) => [p.todoist_id, p])
   );
   const topProjects: DashboardTopProject[] = Array.from(
     projectActiveCounts.entries()
   )
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 6)
     .map(([projectId, count]) => {
       const project = projectsByTodoistId.get(projectId);
+      if (!project) return null;
+      const meta = metadataByProject.get(projectId);
       return {
         todoistId: projectId,
-        name: project?.name ?? "Unknown",
-        color: project?.color ?? "grey",
+        name: project.name,
+        color: project.color,
         activeTaskCount: count,
+        priority: meta?.priority ?? null,
+        scheduledDate: meta?.scheduled_date ?? null,
       };
-    });
+    })
+    .filter((p): p is DashboardTopProject => p !== null)
+    .sort((a, b) => {
+      // Higher priority first (4 > 3 > 2 > 1 > null).
+      const ap = a.priority ?? 0;
+      const bp = b.priority ?? 0;
+      if (ap !== bp) return bp - ap;
+      return b.activeTaskCount - a.activeTaskCount;
+    })
+    .slice(0, 6);
 
-  // Today's queue: tasks due today, sorted by start time when present (timed
-  // items first, in order), then untimed items by content.
-  const todayItems = items.filter((item) => {
+  // Focus queue: surface what to work on next. Rank by priority (P1 > P2 > P3
+  // > P4), tiebreaker by dueness (overdue > today > this week > future > no
+  // date). Inbox tasks excluded since the Inbox card already surfaces them.
+  function duenessScore(item: Doc<"todoist_items">): number {
     const dateOnly = item.due?.date?.includes("T")
       ? item.due.date.split("T")[0]
       : item.due?.date;
-    return dateOnly === todayISO;
+    if (!dateOnly) return 1; // No date
+    if (dateOnly < todayISO) return 5; // Overdue
+    if (dateOnly === todayISO) return 4; // Today
+    if (dateOnly < sevenDaysISO) return 3; // This week
+    return 2; // Future
+  }
+  const focusCandidates = items.filter(
+    (item) => item.project_id !== inboxProjectId
+  );
+  focusCandidates.sort((a, b) => {
+    if (a.priority !== b.priority) return b.priority - a.priority;
+    const aDue = duenessScore(a);
+    const bDue = duenessScore(b);
+    if (aDue !== bDue) return bDue - aDue;
+    // Final tiebreaker: earlier due date wins (lexicographic on YYYY-MM-DD).
+    const aDate = a.due?.date ?? "9999";
+    const bDate = b.due?.date ?? "9999";
+    return aDate.localeCompare(bDate);
   });
-  todayItems.sort((a, b) => {
-    const at = extractStartTime(a.due);
-    const bt = extractStartTime(b.due);
-    if (at && bt) return at.localeCompare(bt);
-    if (at) return -1;
-    if (bt) return 1;
-    return a.content.localeCompare(b.content);
-  });
-  const todayQueue: DashboardTodayQueueItem[] = todayItems
+  const focusQueue: DashboardFocusItem[] = focusCandidates
     .slice(0, 6)
-    .map((item) => ({
-      todoistId: item.todoist_id,
-      content: item.content,
-      priority: item.priority,
-      startTime: extractStartTime(item.due),
-    }));
+    .map((item) => {
+      const project = item.project_id
+        ? projectsByTodoistId.get(item.project_id)
+        : undefined;
+      const dateOnly = item.due?.date?.includes("T")
+        ? item.due.date.split("T")[0]
+        : item.due?.date ?? null;
+      return {
+        todoistId: item.todoist_id,
+        content: item.content,
+        priority: item.priority,
+        projectName: project?.name ?? null,
+        projectColor: project?.color ?? null,
+        dueDate: dateOnly ?? null,
+        isOverdue: dateOnly ? dateOnly < todayISO : false,
+      };
+    });
 
   // Routines summary.
   const activeRoutines = routines.filter((r) => r.defer === false);
@@ -256,7 +310,7 @@ export function aggregateDashboardStats(input: {
       overdueRoutineTasks: overdueRoutineTaskCount,
     },
     topProjects,
-    todayQueue,
+    focusQueue,
     generatedAt: nowMs,
   };
 }
@@ -291,6 +345,10 @@ export const getDashboardStats = query({
       .query("routines")
       .collect();
 
+    const projectMetadata: Doc<"todoist_project_metadata">[] = await ctx.db
+      .query("todoist_project_metadata")
+      .collect();
+
     // Overdue routine tasks: pending status with a dueDate in the past.
     // routineTasks.dueDate is a timestamp (number), not an ISO string.
     const pendingRoutineTasks: Doc<"routineTasks">[] = await ctx.db
@@ -305,6 +363,7 @@ export const getDashboardStats = query({
       items,
       projects,
       routines,
+      projectMetadata,
       overdueRoutineTaskCount,
       todayISO,
       sevenDaysISO,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,10 @@
 import { httpRouter } from "convex/server";
 
+import {
+  handleDiscover as handleBeeperAttachmentsDiscover,
+  handleRecord as handleBeeperAttachmentsRecord,
+  handleUploadUrl as handleBeeperAttachmentsUploadUrl,
+} from "./beeper/sync/handleAttachments";
 import { handleIngest as handleBeeperIngest } from "./beeper/sync/handleIngest";
 import { handleTodoistWebhook } from "./todoist/webhook";
 
@@ -46,6 +51,32 @@ http.route({
   path: "/beeper/ingest",
   method: "POST",
   handler: handleBeeperIngest,
+});
+
+/**
+ * Beeper attachments — Phase B upload pipeline.
+ *
+ * /beeper/attachments/discover — body { mxc_ids: string[] } → which are already uploaded
+ * /beeper/attachments/uploadUrl — body {} → short-lived signed PUT URL
+ * /beeper/attachments/record   — body { mxc_id, convex_storage_id, ... } → register
+ *
+ * All three use the same Bearer-secret auth as /beeper/ingest. See
+ * scripts/upload-beeper-attachments.ts in this repo for the client side.
+ */
+http.route({
+  path: "/beeper/attachments/discover",
+  method: "POST",
+  handler: handleBeeperAttachmentsDiscover,
+});
+http.route({
+  path: "/beeper/attachments/uploadUrl",
+  method: "POST",
+  handler: handleBeeperAttachmentsUploadUrl,
+});
+http.route({
+  path: "/beeper/attachments/record",
+  method: "POST",
+  handler: handleBeeperAttachmentsRecord,
 });
 
 export default http;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,6 @@
 import { httpRouter } from "convex/server";
 
+import { handleIngest as handleBeeperIngest } from "./beeper/sync/handleIngest";
 import { handleTodoistWebhook } from "./todoist/webhook";
 
 /**
@@ -28,6 +29,23 @@ http.route({
   path: "/todoist/webhook",
   method: "POST",
   handler: handleTodoistWebhook,
+});
+
+/**
+ * Beeper ingest endpoint
+ * POST /beeper/ingest
+ *
+ * Receives batched accounts/chats/messages from the local Beeper sync script.
+ * Auth: Bearer token matching the BEEPER_INGEST_SECRET env var on this
+ * deployment (same value as the local script's $BEEPER_INGEST_SECRET).
+ *
+ * See convex/beeper/README.md for the payload shape and the local script at
+ * scripts/sync-beeper.ts in this repo.
+ */
+http.route({
+  path: "/beeper/ingest",
+  method: "POST",
+  handler: handleBeeperIngest,
 });
 
 export default http;

--- a/convex/identity/internal.test.ts
+++ b/convex/identity/internal.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+
+/**
+ * These replicate the merge rules inside upsertIdentitiesBatch and assignCluster
+ * (convex/identity/internal.ts) as plain assertions, matching this repo's
+ * convention of testing mutation business logic without a live Convex db.
+ */
+
+describe("upsertIdentitiesBatch merge rules", () => {
+  test("dedupe key is (network, value), not value alone", () => {
+    const existing = [
+      { value: "+16195551234", network: "whatsapp" },
+      { value: "+16195551234", network: "imessage" },
+    ];
+    const incoming = { value: "+16195551234", network: "imessage" };
+    const match = existing.find((m) => m.network === incoming.network);
+    expect(match?.network).toBe("imessage");
+  });
+
+  test("longer display_name wins on update", () => {
+    const existing = { display_name: "Milad" };
+    const incoming = { display_name: "Milad Imen" };
+    const merged =
+      incoming.display_name && incoming.display_name.length > (existing.display_name?.length ?? 0)
+        ? incoming.display_name
+        : existing.display_name;
+    expect(merged).toBe("Milad Imen");
+  });
+
+  test("shorter or missing incoming display_name does not overwrite existing", () => {
+    const existing = { display_name: "Milad Imen" };
+    const incoming = { display_name: undefined as string | undefined };
+    const merged =
+      incoming.display_name && incoming.display_name.length > (existing.display_name?.length ?? 0)
+        ? incoming.display_name
+        : existing.display_name;
+    expect(merged).toBe("Milad Imen");
+  });
+
+  test("img_url and phone_number are keep-if-existing (first write wins)", () => {
+    const existing = { img_url: "existing.jpg", phone_number: "+16195551234" };
+    const incoming = { img_url: "new.jpg", phone_number: "+19995551234" };
+    expect(existing.img_url ?? incoming.img_url).toBe("existing.jpg");
+    expect(existing.phone_number ?? incoming.phone_number).toBe("+16195551234");
+  });
+
+  test("last_seen_at only advances forward in time", () => {
+    const existing = { last_seen_at: "2026-01-01T00:00:00.000Z" as string | undefined };
+    const older = "2025-06-01T00:00:00.000Z";
+    const newer = "2026-06-01T00:00:00.000Z";
+
+    const mergedWithOlder =
+      older && (!existing.last_seen_at || older > existing.last_seen_at) ? older : existing.last_seen_at;
+    expect(mergedWithOlder).toBe(existing.last_seen_at);
+
+    const mergedWithNewer =
+      newer && (!existing.last_seen_at || newer > existing.last_seen_at) ? newer : existing.last_seen_at;
+    expect(mergedWithNewer).toBe(newer);
+  });
+
+  test("is_self is sticky once true (logical OR, never flips back)", () => {
+    const orTrue = (a: boolean, b: boolean) => a || b;
+    expect(orTrue(true, false)).toBe(true);
+    expect(orTrue(false, true)).toBe(true);
+    expect(orTrue(false, false)).toBe(false);
+  });
+
+  test("chat_count increments by exactly one per upsert", () => {
+    let chatCount = 3;
+    chatCount = chatCount + 1;
+    expect(chatCount).toBe(4);
+  });
+});
+
+describe("assignCluster aggregate rules", () => {
+  test("prefers an existing non-merged person over creating a new one", () => {
+    const identities = [
+      { person_id: undefined },
+      { person_id: "person_a" },
+      { person_id: "person_b" },
+    ];
+    const people = { person_a: { merged_into: "person_c" }, person_b: { merged_into: undefined } };
+
+    let chosen: string | null = null;
+    for (const i of identities) {
+      if (i.person_id) {
+        const p = people[i.person_id as keyof typeof people];
+        if (p && !p.merged_into) {
+          chosen = i.person_id;
+          break;
+        }
+      }
+    }
+    expect(chosen).toBe("person_b");
+  });
+
+  test("normalized values split into phones vs emails by '@' presence", () => {
+    const normalizedValues = ["+16195551234", "milad@example.com", "+442079460958"];
+    const phones = new Set<string>();
+    const emails = new Set<string>();
+    for (const n of normalizedValues) {
+      if (n.includes("@")) emails.add(n);
+      else if (n) phones.add(n);
+    }
+    expect([...phones].sort()).toEqual(["+16195551234", "+442079460958"]);
+    expect([...emails]).toEqual(["milad@example.com"]);
+  });
+
+  test("best display name is the longest non-empty candidate across the cluster", () => {
+    const identities = [{ display_name: "Milad" }, { display_name: "Milad I." }, { display_name: undefined }];
+    let bestName: string | undefined;
+    for (const i of identities) {
+      if (i.display_name && i.display_name.length > (bestName?.length ?? 0)) {
+        bestName = i.display_name;
+      }
+    }
+    expect(bestName).toBe("Milad I.");
+  });
+
+  test("message_count and is_self aggregate across every identity in the cluster", () => {
+    const identities = [
+      { message_count: 10, is_self: false },
+      { message_count: 5, is_self: true },
+      { message_count: 2, is_self: false },
+    ];
+    let messageCount = 0;
+    let isSelf = false;
+    for (const i of identities) {
+      messageCount += i.message_count;
+      isSelf = isSelf || i.is_self;
+    }
+    expect(messageCount).toBe(17);
+    expect(isSelf).toBe(true);
+  });
+});

--- a/convex/identity/internal.ts
+++ b/convex/identity/internal.ts
@@ -1,0 +1,220 @@
+import { v } from "convex/values";
+
+import { internalMutation, internalQuery } from "../_generated/server";
+
+/**
+ * Internal building blocks for the identity resolver. The orchestration lives in
+ * resolve.ts (an action); these are the paged reads and small idempotent writes
+ * it calls so each mutation stays well inside Convex's per-call limits.
+ */
+
+const identityCandidate = v.object({
+  network: v.optional(v.string()),
+  value: v.string(),
+  kind: v.string(),
+  normalized: v.string(),
+  display_name: v.optional(v.string()),
+  phone_number: v.optional(v.string()),
+  img_url: v.optional(v.string()),
+  is_self: v.boolean(),
+  source: v.string(),
+  last_seen_at: v.optional(v.string()),
+});
+
+/** Page through beeper_chats, returning just the fields the resolver needs. */
+export const listChatsPage = internalQuery({
+  args: { cursor: v.union(v.string(), v.null()), numItems: v.number() },
+  handler: async (ctx, { cursor, numItems }) => {
+    const page = await ctx.db
+      .query("beeper_chats")
+      .paginate({ cursor, numItems });
+    return {
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      chats: page.page.map((c) => ({
+        network: c.network,
+        participants: c.participants,
+        last_activity: c.last_activity,
+      })),
+    };
+  },
+});
+
+/**
+ * Idempotent upsert of a batch of identity candidates. Dedupe key is
+ * (network, value): the same raw handle seen in another chat just bumps
+ * chat_count and refreshes last_seen / display_name.
+ */
+export const upsertIdentitiesBatch = internalMutation({
+  args: { items: v.array(identityCandidate) },
+  handler: async (ctx, { items }) => {
+    const now = new Date().toISOString();
+    let inserted = 0;
+    let updated = 0;
+    for (const it of items) {
+      const matches = await ctx.db
+        .query("identities")
+        .withIndex("by_value", (q) => q.eq("value", it.value))
+        .collect();
+      const existing = matches.find((m) => m.network === it.network);
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          chat_count: existing.chat_count + 1,
+          display_name:
+            it.display_name && it.display_name.length > (existing.display_name?.length ?? 0)
+              ? it.display_name
+              : existing.display_name,
+          img_url: existing.img_url ?? it.img_url,
+          phone_number: existing.phone_number ?? it.phone_number,
+          last_seen_at:
+            it.last_seen_at && (!existing.last_seen_at || it.last_seen_at > existing.last_seen_at)
+              ? it.last_seen_at
+              : existing.last_seen_at,
+          is_self: existing.is_self || it.is_self,
+          updated_at: now,
+        });
+        updated++;
+      } else {
+        await ctx.db.insert("identities", {
+          person_id: undefined,
+          kind: it.kind,
+          value: it.value,
+          normalized: it.normalized,
+          network: it.network,
+          display_name: it.display_name,
+          phone_number: it.phone_number,
+          img_url: it.img_url,
+          message_count: 0,
+          chat_count: 1,
+          is_self: it.is_self,
+          source: it.source,
+          first_seen_at: it.last_seen_at ?? now,
+          last_seen_at: it.last_seen_at ?? now,
+          created_at: now,
+          updated_at: now,
+        });
+        inserted++;
+      }
+    }
+    return { inserted, updated };
+  },
+});
+
+/** Page through identities, returning the minimal fields needed to cluster. */
+export const listIdentitiesPage = internalQuery({
+  args: { cursor: v.union(v.string(), v.null()), numItems: v.number() },
+  handler: async (ctx, { cursor, numItems }) => {
+    const page = await ctx.db
+      .query("identities")
+      .withIndex("by_normalized")
+      .paginate({ cursor, numItems });
+    return {
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      identities: page.page.map((i) => ({
+        _id: i._id,
+        normalized: i.normalized,
+      })),
+    };
+  },
+});
+
+/**
+ * Attach every identity sharing one normalized key to a single person, creating
+ * the person if none of them is attached yet. Recomputes the person's aggregates
+ * from its full identity set so re-runs converge.
+ */
+export const assignCluster = internalMutation({
+  args: { identityIds: v.array(v.id("identities")) },
+  handler: async (ctx, { identityIds }) => {
+    if (identityIds.length === 0) return null;
+    const now = new Date().toISOString();
+
+    const ids = (await Promise.all(identityIds.map((id) => ctx.db.get(id)))).filter(
+      (x): x is NonNullable<typeof x> => x !== null,
+    );
+    if (ids.length === 0) return null;
+
+    // Reuse an existing (non-merged) person if any identity already points at one.
+    let personId = null as null | (typeof ids)[number]["person_id"];
+    for (const i of ids) {
+      if (i.person_id) {
+        const p = await ctx.db.get(i.person_id);
+        if (p && !p.merged_into) {
+          personId = i.person_id;
+          break;
+        }
+      }
+    }
+
+    if (!personId) {
+      personId = await ctx.db.insert("people", {
+        display_name: undefined,
+        normalized_phones: [],
+        normalized_emails: [],
+        identity_count: 0,
+        message_count: 0,
+        is_self: false,
+        auto_clustered: true,
+        created_at: now,
+        updated_at: now,
+      });
+    }
+
+    for (const i of ids) {
+      if (i.person_id !== personId) {
+        await ctx.db.patch(i._id, { person_id: personId, updated_at: now });
+      }
+    }
+
+    // Recompute aggregates from the authoritative set: all identities now
+    // pointing at this person.
+    const all = await ctx.db
+      .query("identities")
+      .withIndex("by_person", (q) => q.eq("person_id", personId))
+      .collect();
+    const phones = new Set<string>();
+    const emails = new Set<string>();
+    let messageCount = 0;
+    let isSelf = false;
+    let bestName: string | undefined;
+    for (const i of all) {
+      if (i.normalized.includes("@")) emails.add(i.normalized);
+      else if (i.normalized) phones.add(i.normalized);
+      messageCount += i.message_count;
+      isSelf = isSelf || i.is_self;
+      if (i.display_name && i.display_name.length > (bestName?.length ?? 0)) {
+        bestName = i.display_name;
+      }
+    }
+    await ctx.db.patch(personId, {
+      display_name: bestName,
+      normalized_phones: [...phones],
+      normalized_emails: [...emails],
+      identity_count: all.length,
+      message_count: messageCount,
+      is_self: isSelf,
+      updated_at: now,
+    });
+    return personId;
+  },
+});
+
+/** Aggregate counts for reporting. */
+export const stats = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const identities = await ctx.db.query("identities").collect();
+    const people = await ctx.db.query("people").collect();
+    const unresolved = identities.filter((i) => !i.person_id).length;
+    const noKey = identities.filter((i) => !i.normalized).length;
+    const multiIdentity = people.filter((p) => p.identity_count > 1).length;
+    return {
+      identities: identities.length,
+      unresolved,
+      noNormalizedKey: noKey,
+      people: people.length,
+      peopleWithMultipleIdentities: multiIdentity,
+    };
+  },
+});

--- a/convex/identity/normalize.test.ts
+++ b/convex/identity/normalize.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+
+import { deriveNormalized, kindForNetwork, normalizeEmail, normalizePhone } from "./normalize";
+
+describe("normalizeEmail", () => {
+  test("lowercases and trims", () => {
+    expect(normalizeEmail("  Milad@Example.com  ")).toBe("milad@example.com");
+  });
+
+  test("rejects strings without a plausible email shape", () => {
+    expect(normalizeEmail("not-an-email")).toBe("");
+    expect(normalizeEmail("@missing-local.com")).toBe("");
+    expect(normalizeEmail("missing-domain@")).toBe("");
+  });
+});
+
+describe("normalizePhone", () => {
+  test("bare 10-digit number gets US +1 default", () => {
+    expect(normalizePhone("6195551234")).toBe("+16195551234");
+  });
+
+  test("11-digit number leading 1 gets a plus", () => {
+    expect(normalizePhone("16195551234")).toBe("+16195551234");
+  });
+
+  test("already-plussed international number passes through digits-only", () => {
+    expect(normalizePhone("+44 20 7946 0958")).toBe("+442079460958");
+  });
+
+  test("strips punctuation before counting digits", () => {
+    expect(normalizePhone("(619) 555-1234")).toBe("+16195551234");
+  });
+
+  test("pulls a phone out of a WhatsApp-style JID", () => {
+    expect(normalizePhone("+16195551234@s.whatsapp.net")).toBe("+16195551234");
+  });
+
+  test("too few digits returns empty", () => {
+    expect(normalizePhone("12345")).toBe("");
+  });
+
+  test("empty input returns empty", () => {
+    expect(normalizePhone("")).toBe("");
+  });
+});
+
+describe("kindForNetwork", () => {
+  test("maps known Beeper networks case-insensitively", () => {
+    expect(kindForNetwork("WhatsApp")).toBe("whatsapp");
+    expect(kindForNetwork("Google Messages")).toBe("gmessages");
+    expect(kindForNetwork("gmessages")).toBe("gmessages");
+    expect(kindForNetwork("iMessage")).toBe("imessage");
+    expect(kindForNetwork("Telegram")).toBe("telegram");
+    expect(kindForNetwork("Slack")).toBe("slack");
+    expect(kindForNetwork("slackgo")).toBe("slack");
+    expect(kindForNetwork("Signal")).toBe("signal");
+    expect(kindForNetwork("Matrix")).toBe("matrix");
+  });
+
+  test("unknown or missing network falls back to other", () => {
+    expect(kindForNetwork("carrier-pigeon")).toBe("other");
+    expect(kindForNetwork(undefined)).toBe("other");
+  });
+});
+
+describe("deriveNormalized", () => {
+  test("prefers the separate phone_number field when present", () => {
+    expect(deriveNormalized("@user:beeper.local", "6195551234")).toEqual({
+      normalized: "+16195551234",
+      via: "phone",
+    });
+  });
+
+  test("falls back to extracting a phone from the raw value", () => {
+    expect(deriveNormalized("+16195551234@s.whatsapp.net", undefined)).toEqual({
+      normalized: "+16195551234",
+      via: "phone",
+    });
+  });
+
+  test("falls back to email when no phone is derivable", () => {
+    expect(deriveNormalized("milad@example.com", undefined)).toEqual({
+      normalized: "milad@example.com",
+      via: "email",
+    });
+  });
+
+  test("returns empty/none when neither phone nor email can be derived", () => {
+    expect(deriveNormalized("@bot:matrix.org", undefined)).toEqual({
+      normalized: "",
+      via: "none",
+    });
+  });
+});

--- a/convex/identity/normalize.ts
+++ b/convex/identity/normalize.ts
@@ -1,0 +1,73 @@
+/**
+ * Normalization helpers for the identity graph. The whole clustering model hinges
+ * on `normalized` being a stable join key: two handles for the same human (a
+ * WhatsApp JID and a Google Messages number) must normalize to the same string.
+ */
+
+/** Lowercase + trim an email; returns "" if it doesn't look like one. */
+export function normalizeEmail(raw: string): string {
+  const s = raw.trim().toLowerCase();
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s) ? s : "";
+}
+
+/**
+ * Best-effort E.164. Strips everything but digits (and a leading +), then
+ * applies a US default for bare 10-digit / 11-digit-leading-1 numbers, which is
+ * the overwhelming majority of Milad's contacts. Returns "" if it can't make a
+ * plausible phone (too few digits).
+ */
+export function normalizePhone(raw: string): string {
+  if (!raw) return "";
+  let s = raw.trim();
+  // Pull a phone out of a JID-ish handle like "+15551234567@s.whatsapp.net".
+  const at = s.indexOf("@");
+  if (at !== -1) s = s.slice(0, at);
+  const hadPlus = s.trimStart().startsWith("+");
+  const digits = s.replace(/[^0-9]/g, "");
+  if (digits.length < 7) return "";
+  if (hadPlus) return "+" + digits;
+  if (digits.length === 10) return "+1" + digits;
+  if (digits.length === 11 && digits.startsWith("1")) return "+" + digits;
+  // 11–15 digit international without a plus: trust it as-is.
+  if (digits.length >= 11 && digits.length <= 15) return "+" + digits;
+  return "";
+}
+
+/** Map a Beeper network name to an identity `kind`. */
+export function kindForNetwork(network: string | undefined): string {
+  switch ((network ?? "").toLowerCase()) {
+    case "whatsapp":
+      return "whatsapp";
+    case "google messages":
+    case "gmessages":
+      return "gmessages";
+    case "imessage":
+      return "imessage";
+    case "telegram":
+      return "telegram";
+    case "slack":
+    case "slackgo":
+      return "slack";
+    case "signal":
+      return "signal";
+    case "matrix":
+      return "matrix";
+    default:
+      return "other";
+  }
+}
+
+/**
+ * Derive the best (normalized, normalizationKind) for one participant. Phone
+ * wins when present; otherwise try email; otherwise empty (won't cluster).
+ */
+export function deriveNormalized(
+  value: string,
+  phoneNumber: string | undefined,
+): { normalized: string; via: "phone" | "email" | "none" } {
+  const phone = normalizePhone(phoneNumber ?? "") || normalizePhone(value);
+  if (phone) return { normalized: phone, via: "phone" };
+  const email = normalizeEmail(value);
+  if (email) return { normalized: email, via: "email" };
+  return { normalized: "", via: "none" };
+}

--- a/convex/identity/queries.test.ts
+++ b/convex/identity/queries.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizeEmail, normalizePhone } from "./normalize";
+
+describe("whoIs input normalization", () => {
+  test("normalizes a phone-shaped handle before lookup", () => {
+    const handle = "(619) 555-1234";
+    const normalized = normalizePhone(handle) || normalizeEmail(handle) || handle.trim();
+    expect(normalized).toBe("+16195551234");
+  });
+
+  test("normalizes an email-shaped handle before lookup", () => {
+    const handle = "  Milad@Example.com  ";
+    const normalized = normalizePhone(handle) || normalizeEmail(handle) || handle.trim();
+    expect(normalized).toBe("milad@example.com");
+  });
+
+  test("falls back to the trimmed raw handle when neither phone nor email normalization applies", () => {
+    const handle = "  @weird:matrix.org  ";
+    const normalized = normalizePhone(handle) || normalizeEmail(handle) || handle.trim();
+    expect(normalized).toBe("@weird:matrix.org");
+  });
+
+  test("no matching identity or unresolved person_id reports not found", () => {
+    const match = null as { person_id?: string } | null;
+    const found = Boolean(match?.person_id);
+    expect(found).toBe(false);
+  });
+});
+
+describe("searchPeople filter", () => {
+  const people = [
+    { display_name: "Milad Imen", merged_into: undefined },
+    { display_name: "Mila Kunis", merged_into: undefined },
+    { display_name: "Someone Merged", merged_into: "other_id" },
+    { display_name: undefined, merged_into: undefined },
+  ];
+
+  test("case-insensitive substring match on display_name", () => {
+    const needle = "MILAD".trim().toLowerCase();
+    const matches = people.filter(
+      (p) => !p.merged_into && (p.display_name ?? "").toLowerCase().includes(needle),
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.display_name).toBe("Milad Imen");
+  });
+
+  test("excludes people that were merged away", () => {
+    const needle = "someone";
+    const matches = people.filter(
+      (p) => !p.merged_into && (p.display_name ?? "").toLowerCase().includes(needle),
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  test("people with no display_name never match a non-empty needle", () => {
+    const needle = "anything";
+    const matches = people.filter(
+      (p) => !p.merged_into && (p.display_name ?? "").toLowerCase().includes(needle),
+    );
+    expect(matches.some((p) => p.display_name === undefined)).toBe(false);
+  });
+});
+
+describe("topLinkedPeople selection", () => {
+  test("excludes merged-away people and singletons, sorts by identity_count desc, respects limit", () => {
+    const people = [
+      { display_name: "A", identity_count: 1, merged_into: undefined },
+      { display_name: "B", identity_count: 3, merged_into: undefined },
+      { display_name: "C", identity_count: 5, merged_into: "x" },
+      { display_name: "D", identity_count: 2, merged_into: undefined },
+    ];
+    const result = people
+      .filter((p) => !p.merged_into && p.identity_count > 1)
+      .sort((a, b) => b.identity_count - a.identity_count)
+      .slice(0, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.display_name).toBe("B");
+  });
+
+  test("default limit is 25 when none is supplied", () => {
+    const limit = undefined as number | undefined;
+    expect(limit ?? 25).toBe(25);
+  });
+});

--- a/convex/identity/queries.ts
+++ b/convex/identity/queries.ts
@@ -1,0 +1,63 @@
+import { v } from "convex/values";
+
+import { query } from "../_generated/server";
+
+import { normalizeEmail, normalizePhone } from "./normalize";
+
+/**
+ * Resolve a raw phone / email / handle to the person it belongs to, with all of
+ * that person's known identities. This is the "who is this number, and where
+ * else do I talk to them" lookup.
+ */
+export const whoIs = query({
+  args: { handle: v.string() },
+  handler: async (ctx, { handle }) => {
+    const normalized = normalizePhone(handle) || normalizeEmail(handle) || handle.trim();
+    const match = await ctx.db
+      .query("identities")
+      .withIndex("by_normalized", (q) => q.eq("normalized", normalized))
+      .first();
+    if (!match || !match.person_id) {
+      return { found: false as const, normalized };
+    }
+    const person = await ctx.db.get(match.person_id);
+    if (!person) return { found: false as const, normalized };
+    const identities = await ctx.db
+      .query("identities")
+      .withIndex("by_person", (q) => q.eq("person_id", person._id))
+      .collect();
+    return {
+      found: true as const,
+      normalized,
+      person,
+      identities: identities.map((i) => ({
+        kind: i.kind,
+        network: i.network,
+        value: i.value,
+        normalized: i.normalized,
+        display_name: i.display_name,
+        chat_count: i.chat_count,
+      })),
+    };
+  },
+});
+
+/** The people with the most linked identities — the merge graph's payoff. */
+export const topLinkedPeople = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit }) => {
+    const people = await ctx.db.query("people").collect();
+    return people
+      .filter((p) => !p.merged_into && p.identity_count > 1)
+      .sort((a, b) => b.identity_count - a.identity_count)
+      .slice(0, limit ?? 25)
+      .map((p) => ({
+        _id: p._id,
+        display_name: p.display_name,
+        identity_count: p.identity_count,
+        normalized_phones: p.normalized_phones,
+        normalized_emails: p.normalized_emails,
+        is_self: p.is_self,
+      }));
+  },
+});

--- a/convex/identity/queries.ts
+++ b/convex/identity/queries.ts
@@ -42,6 +42,41 @@ export const whoIs = query({
   },
 });
 
+/** Find people by (case-insensitive substring) display name, with their identities. */
+export const searchPeople = query({
+  args: { name: v.string() },
+  handler: async (ctx, { name }) => {
+    const needle = name.trim().toLowerCase();
+    const people = await ctx.db.query("people").collect();
+    const matches = people.filter(
+      (p) => !p.merged_into && (p.display_name ?? "").toLowerCase().includes(needle),
+    );
+    const out = [];
+    for (const p of matches) {
+      const identities = await ctx.db
+        .query("identities")
+        .withIndex("by_person", (q) => q.eq("person_id", p._id))
+        .collect();
+      out.push({
+        _id: p._id,
+        display_name: p.display_name,
+        identity_count: p.identity_count,
+        normalized_phones: p.normalized_phones,
+        normalized_emails: p.normalized_emails,
+        identities: identities.map((i) => ({
+          kind: i.kind,
+          network: i.network,
+          value: i.value,
+          normalized: i.normalized,
+          display_name: i.display_name,
+          chat_count: i.chat_count,
+        })),
+      });
+    }
+    return out;
+  },
+});
+
 /** The people with the most linked identities — the merge graph's payoff. */
 export const topLinkedPeople = query({
   args: { limit: v.optional(v.number()) },

--- a/convex/identity/resolve.test.ts
+++ b/convex/identity/resolve.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+/**
+ * Replicates the Phase 2 clustering logic in resolveIdentities (convex/identity/resolve.ts):
+ * group identity ids by normalized key, skipping identities with no join key.
+ */
+describe("resolveIdentities clustering", () => {
+  test("groups identity ids by shared normalized key", () => {
+    const identities = [
+      { _id: "id1", normalized: "+16195551234" },
+      { _id: "id2", normalized: "+16195551234" },
+      { _id: "id3", normalized: "milad@example.com" },
+    ];
+    const groups = new Map<string, string[]>();
+    for (const i of identities) {
+      if (!i.normalized) continue;
+      const arr = groups.get(i.normalized) ?? [];
+      arr.push(i._id);
+      groups.set(i.normalized, arr);
+    }
+    expect(groups.get("+16195551234")).toEqual(["id1", "id2"]);
+    expect(groups.get("milad@example.com")).toEqual(["id3"]);
+    expect(groups.size).toBe(2);
+  });
+
+  test("identities with no normalized key are left unclustered", () => {
+    const identities = [
+      { _id: "id1", normalized: "" },
+      { _id: "id2", normalized: "+16195551234" },
+    ];
+    const groups = new Map<string, string[]>();
+    for (const i of identities) {
+      if (!i.normalized) continue;
+      const arr = groups.get(i.normalized) ?? [];
+      arr.push(i._id);
+      groups.set(i.normalized, arr);
+    }
+    expect(groups.has("")).toBe(false);
+    expect(groups.size).toBe(1);
+  });
+
+  test("a single-identity group still produces a cluster of size one", () => {
+    const identities = [{ _id: "id1", normalized: "+16195551234" }];
+    const groups = new Map<string, string[]>();
+    for (const i of identities) {
+      if (!i.normalized) continue;
+      const arr = groups.get(i.normalized) ?? [];
+      arr.push(i._id);
+      groups.set(i.normalized, arr);
+    }
+    expect(groups.get("+16195551234")).toEqual(["id1"]);
+  });
+});

--- a/convex/identity/resolve.ts
+++ b/convex/identity/resolve.ts
@@ -1,0 +1,122 @@
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { internalAction } from "../_generated/server";
+
+import { deriveNormalized, kindForNetwork } from "./normalize";
+
+/**
+ * Build the identity graph from already-ingested Beeper data.
+ *
+ * Phase 1 — walk every chat's participant list and upsert one identity per
+ * distinct (network, handle).
+ * Phase 2 — group identities by their normalized join key (E.164 phone or
+ * lowercased email) and attach each group to a single person.
+ *
+ * Idempotent: safe to re-run after new chats are ingested. Phone is the dominant
+ * join key; cross-key linking (a person's phone AND email) and per-identity
+ * message counts are deliberately out of scope for this pass — see notes.
+ */
+export const resolveIdentities = internalAction({
+  args: {},
+  handler: async (ctx) => {
+    // ---- Phase 1: extract identities from chat participants ----
+    let cursor: string | null = null;
+    let chatsSeen = 0;
+    let candidates = 0;
+    for (;;) {
+      const page: {
+        isDone: boolean;
+        continueCursor: string;
+        chats: Array<{
+          network?: string;
+          last_activity?: string;
+          participants: Array<{
+            id: string;
+            phone_number?: string;
+            full_name?: string;
+            is_self?: boolean;
+            is_admin?: boolean;
+            img_url?: string;
+          }>;
+        }>;
+      } = await ctx.runQuery(internal.identity.internal.listChatsPage, {
+        cursor,
+        numItems: 200,
+      });
+      const batch: Array<{
+        network?: string;
+        value: string;
+        kind: string;
+        normalized: string;
+        display_name?: string;
+        phone_number?: string;
+        img_url?: string;
+        is_self: boolean;
+        source: string;
+        last_seen_at?: string;
+      }> = [];
+      for (const chat of page.chats) {
+        chatsSeen++;
+        for (const p of chat.participants) {
+          if (!p.id) continue;
+          const { normalized } = deriveNormalized(p.id, p.phone_number);
+          batch.push({
+            network: chat.network,
+            value: p.id,
+            kind: kindForNetwork(chat.network),
+            normalized,
+            display_name: p.full_name,
+            phone_number: p.phone_number,
+            img_url: p.img_url,
+            is_self: p.is_self ?? false,
+            source: "participant",
+            last_seen_at: chat.last_activity,
+          });
+        }
+      }
+      // Upsert in sub-batches to keep each mutation small.
+      for (let i = 0; i < batch.length; i += 100) {
+        const slice = batch.slice(i, i + 100);
+        candidates += slice.length;
+        await ctx.runMutation(internal.identity.internal.upsertIdentitiesBatch, {
+          items: slice,
+        });
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+
+    // ---- Phase 2: cluster identities by normalized key ----
+    const groups = new Map<string, Array<Id<"identities">>>();
+    cursor = null;
+    for (;;) {
+      const page: {
+        isDone: boolean;
+        continueCursor: string;
+        identities: Array<{ _id: Id<"identities">; normalized: string }>;
+      } = await ctx.runQuery(internal.identity.internal.listIdentitiesPage, {
+        cursor,
+        numItems: 500,
+      });
+      for (const i of page.identities) {
+        if (!i.normalized) continue; // no join key → leave unclustered
+        const arr = groups.get(i.normalized) ?? [];
+        arr.push(i._id);
+        groups.set(i.normalized, arr);
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
+    }
+
+    let clusters = 0;
+    for (const [, identityIds] of groups) {
+      await ctx.runMutation(internal.identity.internal.assignCluster, {
+        identityIds,
+      });
+      clusters++;
+    }
+
+    const stats = await ctx.runQuery(internal.identity.internal.stats, {});
+    return { chatsSeen, candidates, clusters, ...stats };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,6 +2,7 @@ import { defineSchema } from "convex/server";
 
 // Service table definitions
 import * as beeper from "./schema/beeper";
+import * as identity from "./schema/identity";
 import * as routines from "./schema/routines";
 import { sync_state } from "./schema/sync/syncState";
 import * as todoist from "./schema/todoist";
@@ -17,6 +18,9 @@ export default defineSchema({
 
   // Beeper tables
   ...beeper,
+
+  // Identity graph (cross-network people + identities, Convex-canonical)
+  ...identity,
 
   // Sync management
   sync_state,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1,6 +1,7 @@
 import { defineSchema } from "convex/server";
 
 // Service table definitions
+import * as beeper from "./schema/beeper";
 import * as routines from "./schema/routines";
 import { sync_state } from "./schema/sync/syncState";
 import * as todoist from "./schema/todoist";
@@ -14,11 +15,13 @@ export default defineSchema({
   // Routines tables
   ...routines,
 
+  // Beeper tables
+  ...beeper,
+
   // Sync management
   sync_state,
 
   // Future integrations can add their tables here:
   // ...googleCalendar,
-  // ...beeper,
   // etc.
 });

--- a/convex/schema/beeper/accounts.ts
+++ b/convex/schema/beeper/accounts.ts
@@ -1,0 +1,24 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * One row per connected Beeper account / network bridge.
+ *
+ * `account_id` is Beeper's internal account identifier (e.g. "whatsapp",
+ * "telegram", or per-instance ids like "slackgo.T066U9Q8F99-U066UCP4FS6").
+ *
+ * `network` is the human-readable network name returned by Beeper
+ * ("WhatsApp", "Telegram", "Slack", "Google Messages", "iMessage", "Matrix").
+ */
+export const beeper_accounts = defineTable({
+  account_id: v.string(),
+  network: v.string(),
+  display_name: v.optional(v.string()),
+  phone_number: v.optional(v.string()),
+  is_active: v.boolean(),
+  last_full_sync_at: v.optional(v.string()),
+  last_incremental_sync_at: v.optional(v.string()),
+  raw: v.optional(v.string()),
+})
+  .index("by_account_id", ["account_id"])
+  .index("by_network", ["network"]);

--- a/convex/schema/beeper/attachments.ts
+++ b/convex/schema/beeper/attachments.ts
@@ -1,0 +1,29 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * One row per *unique media file* across all chats / networks. Keyed by
+ * `mxc_id` (Beeper's Matrix media identifier — globally unique and stable
+ * across messages that share an attachment, e.g. forwards).
+ *
+ * `convex_storage_id` is the result of `ctx.storage.store(...)` after we
+ * upload the file bytes; it is the only way to retrieve the file URL later
+ * via `ctx.storage.getUrl(convex_storage_id)`.
+ *
+ * Phase B does NOT patch `messages.attachments[].convex_storage_id` — that
+ * field was reserved in Phase A but we deliberately keep storage IDs only
+ * here, so the messages table is immutable post-ingest and there is one
+ * source of truth for "where are the bytes." Lookups join through this table.
+ */
+export const beeper_attachments = defineTable({
+  mxc_id: v.string(),
+  convex_storage_id: v.string(),
+  network: v.string(),
+  mime_type: v.optional(v.string()),
+  file_name: v.optional(v.string()),
+  file_size: v.optional(v.number()),
+  width: v.optional(v.number()),
+  height: v.optional(v.number()),
+  duration_ms: v.optional(v.number()),
+  uploaded_at: v.string(),
+}).index("by_mxc_id", ["mxc_id"]);

--- a/convex/schema/beeper/chats.ts
+++ b/convex/schema/beeper/chats.ts
@@ -1,0 +1,59 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * One row per chat across all Beeper networks.
+ *
+ * Identity is the Beeper/Matrix room id in `chat_id`. We additionally store the
+ * network-side native id in `local_chat_id` (e.g. WhatsApp's numeric internal id)
+ * for forensic lookups.
+ *
+ * `participants` is denormalised JSON because Beeper returns nested objects
+ * with mutable fields (avatars, "isAdmin", etc.) we don't want to model fully.
+ * The raw chat blob is preserved in `raw` so a future migration can re-derive
+ * structured fields without re-ingesting from Beeper.
+ */
+const participantSchema = v.object({
+  id: v.string(),
+  phone_number: v.optional(v.string()),
+  full_name: v.optional(v.string()),
+  is_self: v.optional(v.boolean()),
+  is_admin: v.optional(v.boolean()),
+  img_url: v.optional(v.string()),
+});
+
+export const beeper_chats = defineTable({
+  account_id: v.string(),
+  network: v.string(),
+
+  chat_id: v.string(),           // Beeper/Matrix room id (globally unique)
+  local_chat_id: v.optional(v.string()),
+
+  title: v.optional(v.string()),
+  description: v.optional(v.string()),
+  type: v.string(),              // "single" | "group" | other
+  img_url: v.optional(v.string()),
+
+  participants: v.array(participantSchema),
+  participant_count: v.number(),
+
+  last_activity: v.optional(v.string()),       // ISO timestamp
+  last_activity_epoch_ms: v.optional(v.number()),
+
+  is_archived: v.boolean(),
+  is_muted: v.boolean(),
+  is_pinned: v.boolean(),
+  is_read_only: v.boolean(),
+  unread_count: v.number(),
+
+  first_seen_at: v.string(),                   // when we first synced it
+  last_synced_at: v.string(),
+  message_count: v.number(),                   // best-effort, updated on backfill
+
+  raw: v.optional(v.string()),                 // JSON.stringify of original chat blob
+})
+  .index("by_chat_id", ["chat_id"])
+  .index("by_account", ["account_id"])
+  .index("by_network", ["network"])
+  .index("by_network_activity", ["network", "last_activity_epoch_ms"])
+  .index("by_last_activity", ["last_activity_epoch_ms"]);

--- a/convex/schema/beeper/index.ts
+++ b/convex/schema/beeper/index.ts
@@ -1,0 +1,4 @@
+// Barrel export for all Beeper table definitions
+export { beeper_accounts } from "./accounts";
+export { beeper_chats } from "./chats";
+export { beeper_messages } from "./messages";

--- a/convex/schema/beeper/index.ts
+++ b/convex/schema/beeper/index.ts
@@ -1,4 +1,5 @@
 // Barrel export for all Beeper table definitions
 export { beeper_accounts } from "./accounts";
+export { beeper_attachments } from "./attachments";
 export { beeper_chats } from "./chats";
 export { beeper_messages } from "./messages";

--- a/convex/schema/beeper/messages.ts
+++ b/convex/schema/beeper/messages.ts
@@ -1,0 +1,76 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * One row per Beeper message. Identity = (chat_id, message_id) because
+ * Beeper's per-message numeric id is only unique inside a chat.
+ *
+ * `attachments` is JSON because the schema varies by media type and we want
+ * the Phase-B uploader to be able to enrich rows in place by adding
+ * convex_storage_id without changing the row's shape from the writer's POV.
+ *
+ * `sort_key` is Beeper's monotonic per-chat sort key (string of digits in
+ * practice; we compare lexicographically when lengths are equal, so we also
+ * store ts_epoch_ms for cross-chat range queries / sorting).
+ *
+ * `text` is mirrored at the top level (not inside `raw`) so the search index
+ * can be defined over it.
+ */
+const reactionSchema = v.object({
+  participant_id: v.string(),
+  emoji_or_key: v.string(),
+});
+
+const attachmentSchema = v.object({
+  mxc_id: v.string(),               // mxc://... — primary key for dedupe in Phase B
+  type: v.optional(v.string()),     // img | video | audio | file | sticker | gif
+  mime_type: v.optional(v.string()),
+  file_name: v.optional(v.string()),
+  file_size: v.optional(v.number()),
+  width: v.optional(v.number()),
+  height: v.optional(v.number()),
+  duration_ms: v.optional(v.number()),
+  is_gif: v.optional(v.boolean()),
+  is_sticker: v.optional(v.boolean()),
+  beeper_src_url: v.optional(v.string()),    // file:// path inside Beeper's media cache at ingest time
+  convex_storage_id: v.optional(v.string()), // populated by Phase B
+});
+
+export const beeper_messages = defineTable({
+  account_id: v.string(),
+  network: v.string(),
+  chat_id: v.string(),
+
+  message_id: v.string(),
+  sort_key: v.optional(v.string()),
+
+  sender_id: v.optional(v.string()),
+  sender_name: v.optional(v.string()),
+  is_sender: v.boolean(),
+
+  timestamp: v.optional(v.string()),     // ISO
+  ts_epoch_ms: v.optional(v.number()),
+
+  type: v.optional(v.string()),          // TEXT | IMAGE | VIDEO | FILE | VOICE | LOCATION | REACTION | NOTICE | ...
+  text: v.string(),                      // empty string for media-only messages
+
+  reactions: v.array(reactionSchema),
+  attachments: v.array(attachmentSchema),
+
+  reply_to_message_id: v.optional(v.string()),  // for REACTION + reply messages
+  is_deleted: v.boolean(),
+  is_hidden: v.boolean(),
+
+  first_seen_at: v.string(),
+  last_synced_at: v.string(),
+
+  raw: v.optional(v.string()),           // JSON.stringify of original message blob
+})
+  .index("by_chat_message", ["chat_id", "message_id"])
+  .index("by_chat_recent", ["chat_id", "ts_epoch_ms"])
+  .index("by_network_recent", ["network", "ts_epoch_ms"])
+  .index("by_sender", ["sender_id"])
+  .searchIndex("search_text", {
+    searchField: "text",
+    filterFields: ["chat_id", "network", "sender_id", "is_sender", "type"],
+  });

--- a/convex/schema/identity/identities.ts
+++ b/convex/schema/identity/identities.ts
@@ -1,0 +1,44 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * A single network handle: one phone / email / WhatsApp JID / iMessage address /
+ * Slack user id / Telegram id / Matrix id. High-volume, machine-generated — one
+ * per distinct handle ever seen across all bridged networks.
+ *
+ * Identity key = `value` (the raw handle as the network presents it). The same
+ * human's phone can appear as BOTH a WhatsApp JID and a Google Messages number;
+ * those are two identity rows with different `value`s but the same `normalized`
+ * phone — and that shared `normalized` is exactly what the resolver clusters on
+ * to attach both to one `person_id`.
+ *
+ * `person_id` is null until the resolver attaches it.
+ */
+export const identities = defineTable({
+  person_id: v.optional(v.id("people")), // null until resolved
+
+  kind: v.string(), // phone | email | whatsapp | imessage | gmessages | slack | telegram | matrix | other
+  value: v.string(), // raw handle as seen on the network
+  normalized: v.string(), // E.164 for phones, lowercased for email, else value
+
+  network: v.optional(v.string()), // beeper network where first seen
+  display_name: v.optional(v.string()),
+  phone_number: v.optional(v.string()), // if the network exposed one separately
+  img_url: v.optional(v.string()),
+
+  message_count: v.number(),
+  chat_count: v.number(),
+
+  is_self: v.boolean(),
+  source: v.string(), // participant | sender | manual
+
+  first_seen_at: v.optional(v.string()),
+  last_seen_at: v.optional(v.string()),
+  created_at: v.string(),
+  updated_at: v.string(),
+})
+  .index("by_value", ["value"])
+  .index("by_normalized", ["normalized"])
+  .index("by_person", ["person_id"])
+  .index("by_kind_normalized", ["kind", "normalized"])
+  .index("by_unresolved", ["person_id", "normalized"]);

--- a/convex/schema/identity/index.ts
+++ b/convex/schema/identity/index.ts
@@ -1,0 +1,3 @@
+// Barrel export for the cross-network identity graph (Convex-canonical).
+export { identities } from "./identities";
+export { people } from "./people";

--- a/convex/schema/identity/people.ts
+++ b/convex/schema/identity/people.ts
@@ -1,0 +1,45 @@
+import { defineTable } from "convex/server";
+import { v } from "convex/values";
+
+/**
+ * A canonical person — a real human that one or more network identities belong
+ * to. Convex is the source of truth for the identity graph (decided 2026-06-20):
+ * `people` + `identities` both live here; Airtable Humans is an optional
+ * downstream link via `airtable_human_id`, not the source.
+ *
+ * Most rows are created automatically by the resolver (`auto_clustered: true`)
+ * by grouping identities that share a normalized phone / email. Hand-curated or
+ * manually-merged people set `auto_clustered: false`.
+ *
+ * `merged_into` tombstones a person that was merged away: when two clusters turn
+ * out to be the same human, the loser's identities are repointed to the winner
+ * and the loser keeps a `merged_into` pointer so old references still resolve.
+ */
+export const people = defineTable({
+  display_name: v.optional(v.string()),
+
+  // Denormalised join keys, for fast "who owns this number" lookups without
+  // walking the identities table.
+  normalized_phones: v.array(v.string()),
+  normalized_emails: v.array(v.string()),
+
+  identity_count: v.number(),
+  message_count: v.number(),
+
+  is_self: v.boolean(), // the cluster that is Milad himself
+
+  notes: v.optional(v.string()),
+
+  // Optional downstream links — Convex stays canonical, these just point out.
+  airtable_human_id: v.optional(v.string()),
+  vault_entity: v.optional(v.string()),
+
+  auto_clustered: v.boolean(), // true = resolver-made, false = hand-curated
+  merged_into: v.optional(v.id("people")), // tombstone if merged away
+
+  created_at: v.string(),
+  updated_at: v.string(),
+})
+  .index("by_airtable_human", ["airtable_human_id"])
+  .index("by_is_self", ["is_self"])
+  .index("by_merged_into", ["merged_into"]);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,6 +79,19 @@ export default [
     },
   },
   {
+    // CLI scripts run under Bun — full Node globals + console output IS the UX.
+    files: ['scripts/**/*.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        Bun: 'readonly',
+      },
+    },
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
     files: ['**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts', '**/*.spec.tsx', '**/test_utils/**/*.ts'],
     languageOptions: {
       globals: {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "sync:initial": "bunx convex run todoist/sync:runInitialSync",
+    "sync:beeper": "bun run scripts/sync-beeper.ts",
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "sync:initial": "bunx convex run todoist/sync:runInitialSync",
     "sync:beeper": "bun run scripts/sync-beeper.ts",
+    "sync:beeper:attachments": "bun run scripts/upload-beeper-attachments.ts",
     "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:watch": "vitest",

--- a/scripts/sync-beeper.ts
+++ b/scripts/sync-beeper.ts
@@ -484,12 +484,14 @@ async function main(): Promise<void> {
     }
 
     totalMessages += messages.length;
-    doneSet.add(c.id);
-    saveProgress({
-      account: ARGS.account,
-      done: Array.from(doneSet),
-      lastUpdated: new Date().toISOString(),
-    });
+    if (!ARGS.dryRun) {
+      doneSet.add(c.id);
+      saveProgress({
+        account: ARGS.account,
+        done: Array.from(doneSet),
+        lastUpdated: new Date().toISOString(),
+      });
+    }
 
     const elapsed = (Date.now() - started) / 1000;
     console.log(

--- a/scripts/sync-beeper.ts
+++ b/scripts/sync-beeper.ts
@@ -1,0 +1,513 @@
+#!/usr/bin/env bun
+/**
+ * Sync Beeper Desktop's local-API contents into Convex.
+ *
+ * Phase A: ingest chats + messages metadata for a single Beeper account
+ * (defaults to WhatsApp). Attachment bytes are NOT uploaded — only the
+ * `mxc_id` + metadata are stored. The Phase B uploader will fill in
+ * convex_storage_id later by walking attachments missing it.
+ *
+ * Usage:
+ *   bun run scripts/sync-beeper.ts                       # WhatsApp full backfill
+ *   bun run scripts/sync-beeper.ts --account telegram    # other network
+ *   bun run scripts/sync-beeper.ts --since-days 7        # only chats with activity in last N days
+ *   bun run scripts/sync-beeper.ts --limit-chats 5       # smoke test
+ *
+ * Env (in .env.local):
+ *   BEEPER_URL                 default http://localhost:23373/v1
+ *   BEEPER_ACCESS_TOKEN        required — Beeper Desktop developer token
+ *   CONVEX_INGEST_URL          required — https://<deployment>.convex.site/beeper/ingest
+ *   BEEPER_INGEST_SECRET       required — shared secret matching the Convex env var
+ *
+ * Resumability: the script tracks per-chat completion in a local progress
+ * file (.beeper-sync-progress.json) alongside the script. Re-runs skip
+ * already-completed chats unless --refresh is passed.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+// ---------------------------- args & env -------------------------------------
+
+type Args = {
+  account: string;
+  sinceDays?: number;
+  limitChats?: number;
+  refresh: boolean;
+  dryRun: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { account: "whatsapp", refresh: false, dryRun: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--account") args.account = argv[++i] ?? args.account;
+    else if (a === "--since-days") args.sinceDays = Number(argv[++i]);
+    else if (a === "--limit-chats") args.limitChats = Number(argv[++i]);
+    else if (a === "--refresh") args.refresh = true;
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function usage(): string {
+  return `Usage: bun run scripts/sync-beeper.ts [--account whatsapp] [--since-days N] [--limit-chats N] [--refresh] [--dry-run]`;
+}
+
+const ARGS = parseArgs(Bun.argv.slice(2));
+
+const BEEPER_URL = process.env.BEEPER_URL ?? "http://localhost:23373/v1";
+const BEEPER_TOKEN = process.env.BEEPER_ACCESS_TOKEN;
+const CONVEX_INGEST_URL = process.env.CONVEX_INGEST_URL;
+const INGEST_SECRET = process.env.BEEPER_INGEST_SECRET;
+
+if (!BEEPER_TOKEN) die("BEEPER_ACCESS_TOKEN not set");
+if (!ARGS.dryRun && !CONVEX_INGEST_URL) die("CONVEX_INGEST_URL not set");
+if (!ARGS.dryRun && !INGEST_SECRET) die("BEEPER_INGEST_SECRET not set");
+
+const PROGRESS_PATH = join(import.meta.dir, ".beeper-sync-progress.json");
+
+// ---------------------------- types ------------------------------------------
+
+interface BeeperListResp<T> {
+  items: T[];
+  hasMore: boolean;
+  oldestCursor: string | null;
+  newestCursor: string | null;
+}
+
+interface BeeperParticipant {
+  id: string;
+  phoneNumber?: string;
+  fullName?: string;
+  isSelf?: boolean;
+  isAdmin?: boolean;
+  imgURL?: string;
+}
+
+interface BeeperChat {
+  id: string;
+  localChatID?: string;
+  accountID: string;
+  network: string;
+  title?: string;
+  description?: string;
+  imgURL?: string | null;
+  type: string;
+  isReadOnly?: boolean;
+  participants?: { items: BeeperParticipant[]; hasMore?: boolean; total?: number };
+  lastActivity?: string;
+  unreadCount?: number;
+  isArchived?: boolean;
+  isMuted?: boolean;
+  isPinned?: boolean;
+}
+
+interface BeeperAttachment {
+  id: string;          // mxc://...
+  type?: string;
+  mimeType?: string;
+  fileName?: string;
+  fileSize?: number;
+  isGif?: boolean;
+  isSticker?: boolean;
+  size?: { width?: number; height?: number };
+  duration?: number;
+  srcURL?: string;
+}
+
+interface BeeperReaction {
+  id?: string;
+  participantID?: string;
+  reactionKey?: string;
+  emoji?: boolean | string;
+}
+
+interface BeeperMessage {
+  id: string;
+  chatID: string;
+  accountID: string;
+  senderID?: string;
+  senderName?: string;
+  timestamp?: string;
+  sortKey?: string;
+  type?: string;
+  text?: string;
+  isSender?: boolean;
+  isHidden?: boolean;
+  isDeleted?: boolean;
+  mentions?: unknown[];
+  attachments?: BeeperAttachment[];
+  reactions?: BeeperReaction[];
+  linkedMessageID?: string;
+}
+
+interface BeeperAccount {
+  network: string;
+  accountID: string;
+  user?: { displayName?: string; phoneNumber?: string };
+}
+
+type Progress = {
+  account: string;
+  done: string[];
+  lastUpdated: string;
+};
+
+// ---------------------------- Beeper HTTP ------------------------------------
+
+async function beeperGet<T>(path: string): Promise<T> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const res = await fetch(`${BEEPER_URL}${path}`, {
+        headers: { Authorization: `Bearer ${BEEPER_TOKEN}` },
+      });
+      if (!res.ok) {
+        throw new Error(`Beeper ${res.status} ${res.statusText} for ${path}`);
+      }
+      return (await res.json()) as T;
+    } catch (e) {
+      if (attempt === 4) throw e;
+      const wait = 250 * 2 ** attempt;
+      console.error(`  ! ${e}; retrying in ${wait}ms`);
+      await sleep(wait);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+async function fetchAccount(accountId: string): Promise<BeeperAccount> {
+  const all = await beeperGet<BeeperAccount[]>("/accounts");
+  const found = all.find((a) => a.accountID === accountId);
+  if (!found) die(`Beeper has no connected account with id "${accountId}"`);
+  return found;
+}
+
+async function fetchAllChats(accountId: string): Promise<BeeperChat[]> {
+  const chats: BeeperChat[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const qs = new URLSearchParams({ accountIDs: accountId, limit: "200" });
+    if (cursor) qs.set("cursor", cursor);
+    const data = await beeperGet<BeeperListResp<BeeperChat>>(
+      `/chats/search?${qs.toString()}`,
+    );
+    chats.push(...data.items);
+    if (!data.hasMore || !data.oldestCursor) break;
+    cursor = data.oldestCursor;
+    await sleep(20);
+  }
+  return chats;
+}
+
+async function fetchAllMessages(chatId: string): Promise<BeeperMessage[]> {
+  const enc = encodeURIComponent(chatId);
+  const msgs: BeeperMessage[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const qs = new URLSearchParams({ limit: "500" });
+    if (cursor) qs.set("cursor", cursor);
+    const data = await beeperGet<BeeperListResp<BeeperMessage>>(
+      `/chats/${enc}/messages?${qs.toString()}`,
+    );
+    msgs.push(...data.items);
+    if (!data.hasMore || !data.oldestCursor) break;
+    cursor = data.oldestCursor;
+    await sleep(20);
+  }
+  // sort oldest -> newest by sortKey (lexicographic on equal length, fallback ts)
+  msgs.sort((a, b) => {
+    const sa = a.sortKey ?? "";
+    const sb = b.sortKey ?? "";
+    if (sa.length !== sb.length) return sa.length - sb.length;
+    if (sa !== sb) return sa < sb ? -1 : 1;
+    return (a.timestamp ?? "").localeCompare(b.timestamp ?? "");
+  });
+  return msgs;
+}
+
+// ---------------------------- shape conversion -------------------------------
+
+function reshapeAccount(a: BeeperAccount): Record<string, unknown> {
+  return {
+    account_id: a.accountID,
+    network: a.network,
+    display_name: a.user?.displayName ?? undefined,
+    phone_number: a.user?.phoneNumber ?? undefined,
+    is_active: true,
+    raw: JSON.stringify(a),
+  };
+}
+
+function reshapeChat(c: BeeperChat): Record<string, unknown> {
+  const participants = (c.participants?.items ?? []).map((p) => ({
+    id: p.id,
+    phone_number: p.phoneNumber,
+    full_name: p.fullName,
+    is_self: p.isSelf,
+    is_admin: p.isAdmin,
+    img_url: p.imgURL,
+  }));
+  return {
+    account_id: c.accountID,
+    network: c.network,
+    chat_id: c.id,
+    local_chat_id: c.localChatID,
+    title: c.title,
+    description: c.description,
+    type: c.type,
+    img_url: c.imgURL ?? undefined,
+    participants,
+    last_activity: c.lastActivity,
+    is_archived: c.isArchived ?? false,
+    is_muted: c.isMuted ?? false,
+    is_pinned: c.isPinned ?? false,
+    is_read_only: c.isReadOnly ?? false,
+    unread_count: c.unreadCount ?? 0,
+    raw: JSON.stringify(c),
+  };
+}
+
+function reshapeMessage(m: BeeperMessage): Record<string, unknown> {
+  const attachments = (m.attachments ?? []).map((a) => ({
+    mxc_id: a.id,
+    type: a.type,
+    mime_type: a.mimeType,
+    file_name: a.fileName,
+    file_size: a.fileSize,
+    width: a.size?.width,
+    height: a.size?.height,
+    duration_ms: a.duration,
+    is_gif: a.isGif,
+    is_sticker: a.isSticker,
+    beeper_src_url: a.srcURL,
+  }));
+  const reactions = (m.reactions ?? [])
+    .filter((r) => r.participantID && r.reactionKey)
+    .map((r) => ({
+      participant_id: r.participantID as string,
+      emoji_or_key: r.reactionKey as string,
+    }));
+  return {
+    account_id: m.accountID,
+    network: "WhatsApp", // overwritten below from chat context
+    chat_id: m.chatID,
+    message_id: m.id,
+    sort_key: m.sortKey,
+    sender_id: m.senderID,
+    sender_name: m.senderName,
+    is_sender: m.isSender ?? false,
+    timestamp: m.timestamp,
+    type: m.type,
+    text: m.text ?? "",
+    reactions,
+    attachments,
+    reply_to_message_id: m.linkedMessageID,
+    is_deleted: m.isDeleted ?? false,
+    is_hidden: m.isHidden ?? false,
+    raw: JSON.stringify(m),
+  };
+}
+
+// ---------------------------- Convex POST ------------------------------------
+
+interface IngestPayload {
+  accounts?: Record<string, unknown>[];
+  chats?: Record<string, unknown>[];
+  messages_by_chat?: { chat_id: string; messages: Record<string, unknown>[] }[];
+  mark_full_sync_started?: boolean;
+  mark_synced?: { account_id: string; sync_type: "full" | "incremental" };
+}
+
+async function postIngest(payload: IngestPayload): Promise<void> {
+  if (ARGS.dryRun) {
+    const sizes = {
+      accounts: payload.accounts?.length ?? 0,
+      chats: payload.chats?.length ?? 0,
+      msgGroups: payload.messages_by_chat?.length ?? 0,
+      totalMessages:
+        payload.messages_by_chat?.reduce((n, g) => n + g.messages.length, 0) ??
+        0,
+    };
+    console.log(`  [dry-run] would POST ${JSON.stringify(sizes)}`);
+    return;
+  }
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const res = await fetch(CONVEX_INGEST_URL!, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${INGEST_SECRET}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Convex ${res.status} ${res.statusText}: ${body}`);
+      }
+      return;
+    } catch (e) {
+      if (attempt === 4) throw e;
+      const wait = 500 * 2 ** attempt;
+      console.error(`  ! ingest failed (${e}); retrying in ${wait}ms`);
+      await sleep(wait);
+    }
+  }
+}
+
+// ---------------------------- progress ---------------------------------------
+
+function loadProgress(account: string): Progress {
+  if (!existsSync(PROGRESS_PATH)) {
+    return { account, done: [], lastUpdated: new Date().toISOString() };
+  }
+  const all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<
+    string,
+    Progress
+  >;
+  return (
+    all[account] ?? { account, done: [], lastUpdated: new Date().toISOString() }
+  );
+}
+
+function saveProgress(p: Progress): void {
+  let all: Record<string, Progress> = {};
+  if (existsSync(PROGRESS_PATH)) {
+    all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<
+      string,
+      Progress
+    >;
+  }
+  p.lastUpdated = new Date().toISOString();
+  all[p.account] = p;
+  writeFileSync(PROGRESS_PATH, JSON.stringify(all, null, 2));
+}
+
+// ---------------------------- main -------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+function die(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+async function main(): Promise<void> {
+  console.log(
+    `Beeper sync — account=${ARGS.account} dryRun=${ARGS.dryRun} refresh=${ARGS.refresh}`,
+  );
+
+  // 1) account
+  const account = await fetchAccount(ARGS.account);
+  console.log(
+    `\n[1/3] account: ${account.network} (${account.accountID}) ${account.user?.phoneNumber ?? ""}`,
+  );
+  await postIngest({
+    accounts: [reshapeAccount(account)],
+    mark_full_sync_started: true,
+  });
+
+  // 2) chats
+  console.log(`\n[2/3] fetching all chats for ${ARGS.account}...`);
+  let chats = await fetchAllChats(ARGS.account);
+  console.log(`  found ${chats.length} chats`);
+
+  if (ARGS.sinceDays !== undefined) {
+    const cutoff = Date.now() - ARGS.sinceDays * 86_400_000;
+    chats = chats.filter(
+      (c) => !c.lastActivity || new Date(c.lastActivity).getTime() >= cutoff,
+    );
+    console.log(`  filtered to ${chats.length} active in last ${ARGS.sinceDays}d`);
+  }
+  if (ARGS.limitChats !== undefined) {
+    chats = chats.slice(0, ARGS.limitChats);
+    console.log(`  capped at ${chats.length} chats (--limit-chats)`);
+  }
+
+  // Upsert all chat rows up-front so dashboards see the universe immediately.
+  const chatBatchSize = 50;
+  for (let i = 0; i < chats.length; i += chatBatchSize) {
+    const slice = chats.slice(i, i + chatBatchSize);
+    await postIngest({ chats: slice.map(reshapeChat) });
+    console.log(`  posted chat rows ${i + 1}-${i + slice.length}/${chats.length}`);
+  }
+
+  // 3) messages
+  console.log(`\n[3/3] fetching messages...`);
+  const progress = loadProgress(ARGS.account);
+  const doneSet = new Set(progress.done);
+
+  let totalMessages = 0;
+  const started = Date.now();
+  for (let i = 0; i < chats.length; i += 1) {
+    const c = chats[i]!;
+    const tag = `[${i + 1}/${chats.length}] ${c.title ?? "(no title)"} (${c.type})`;
+    if (!ARGS.refresh && doneSet.has(c.id)) {
+      console.log(`  ${tag} — skip (already done)`);
+      continue;
+    }
+    console.log(`  ${tag}`);
+
+    let messages: BeeperMessage[];
+    try {
+      messages = await fetchAllMessages(c.id);
+    } catch (e) {
+      console.error(`    ! fetch failed: ${e}`);
+      continue;
+    }
+
+    // Post in chunks of 500 messages.
+    const network = c.network;
+    const chunkSize = 500;
+    for (let j = 0; j < messages.length; j += chunkSize) {
+      const slice = messages.slice(j, j + chunkSize);
+      const payload: IngestPayload = {
+        messages_by_chat: [
+          {
+            chat_id: c.id,
+            messages: slice.map((m) => {
+              const reshaped = reshapeMessage(m);
+              reshaped.network = network;
+              return reshaped;
+            }),
+          },
+        ],
+      };
+      await postIngest(payload);
+    }
+
+    totalMessages += messages.length;
+    doneSet.add(c.id);
+    saveProgress({
+      account: ARGS.account,
+      done: Array.from(doneSet),
+      lastUpdated: new Date().toISOString(),
+    });
+
+    const elapsed = (Date.now() - started) / 1000;
+    console.log(
+      `    posted ${messages.length} messages (running ${totalMessages}, elapsed ${elapsed.toFixed(1)}s)`,
+    );
+  }
+
+  // 4) mark synced
+  await postIngest({
+    mark_synced: { account_id: ARGS.account, sync_type: "full" },
+  });
+
+  console.log(
+    `\ndone. chats=${chats.length} messages=${totalMessages} elapsed=${((Date.now() - started) / 1000).toFixed(1)}s`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/sync-beeper.ts
+++ b/scripts/sync-beeper.ts
@@ -232,27 +232,42 @@ async function fetchAllMessages(chatId: string): Promise<BeeperMessage[]> {
 
 // ---------------------------- shape conversion -------------------------------
 
+/**
+ * Convex `v.optional(v.string())` validators accept `undefined` but reject
+ * `null`. Beeper returns `null` for many "no value" fields. Drop nulls before
+ * serializing so the optional-field semantics match.
+ */
+function stripNulls<T extends Record<string, unknown>>(obj: T): T {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== null) out[k] = v;
+  }
+  return out as T;
+}
+
 function reshapeAccount(a: BeeperAccount): Record<string, unknown> {
-  return {
+  return stripNulls({
     account_id: a.accountID,
     network: a.network,
-    display_name: a.user?.displayName ?? undefined,
-    phone_number: a.user?.phoneNumber ?? undefined,
+    display_name: a.user?.displayName,
+    phone_number: a.user?.phoneNumber,
     is_active: true,
     raw: JSON.stringify(a),
-  };
+  });
 }
 
 function reshapeChat(c: BeeperChat): Record<string, unknown> {
-  const participants = (c.participants?.items ?? []).map((p) => ({
-    id: p.id,
-    phone_number: p.phoneNumber,
-    full_name: p.fullName,
-    is_self: p.isSelf,
-    is_admin: p.isAdmin,
-    img_url: p.imgURL,
-  }));
-  return {
+  const participants = (c.participants?.items ?? []).map((p) =>
+    stripNulls({
+      id: p.id,
+      phone_number: p.phoneNumber,
+      full_name: p.fullName,
+      is_self: p.isSelf,
+      is_admin: p.isAdmin,
+      img_url: p.imgURL,
+    }),
+  );
+  return stripNulls({
     account_id: c.accountID,
     network: c.network,
     chat_id: c.id,
@@ -260,7 +275,7 @@ function reshapeChat(c: BeeperChat): Record<string, unknown> {
     title: c.title,
     description: c.description,
     type: c.type,
-    img_url: c.imgURL ?? undefined,
+    img_url: c.imgURL,
     participants,
     last_activity: c.lastActivity,
     is_archived: c.isArchived ?? false,
@@ -269,30 +284,32 @@ function reshapeChat(c: BeeperChat): Record<string, unknown> {
     is_read_only: c.isReadOnly ?? false,
     unread_count: c.unreadCount ?? 0,
     raw: JSON.stringify(c),
-  };
+  });
 }
 
 function reshapeMessage(m: BeeperMessage): Record<string, unknown> {
-  const attachments = (m.attachments ?? []).map((a) => ({
-    mxc_id: a.id,
-    type: a.type,
-    mime_type: a.mimeType,
-    file_name: a.fileName,
-    file_size: a.fileSize,
-    width: a.size?.width,
-    height: a.size?.height,
-    duration_ms: a.duration,
-    is_gif: a.isGif,
-    is_sticker: a.isSticker,
-    beeper_src_url: a.srcURL,
-  }));
+  const attachments = (m.attachments ?? []).map((a) =>
+    stripNulls({
+      mxc_id: a.id,
+      type: a.type,
+      mime_type: a.mimeType,
+      file_name: a.fileName,
+      file_size: a.fileSize,
+      width: a.size?.width,
+      height: a.size?.height,
+      duration_ms: a.duration,
+      is_gif: a.isGif,
+      is_sticker: a.isSticker,
+      beeper_src_url: a.srcURL,
+    }),
+  );
   const reactions = (m.reactions ?? [])
     .filter((r) => r.participantID && r.reactionKey)
     .map((r) => ({
       participant_id: r.participantID as string,
       emoji_or_key: r.reactionKey as string,
     }));
-  return {
+  return stripNulls({
     account_id: m.accountID,
     network: "WhatsApp", // overwritten below from chat context
     chat_id: m.chatID,
@@ -310,7 +327,7 @@ function reshapeMessage(m: BeeperMessage): Record<string, unknown> {
     is_deleted: m.isDeleted ?? false,
     is_hidden: m.isHidden ?? false,
     raw: JSON.stringify(m),
-  };
+  });
 }
 
 // ---------------------------- Convex POST ------------------------------------

--- a/scripts/upload-beeper-attachments.ts
+++ b/scripts/upload-beeper-attachments.ts
@@ -1,0 +1,439 @@
+#!/usr/bin/env bun
+/**
+ * Phase B uploader — copies Beeper's locally-cached attachment bytes into
+ * Convex File Storage, dedupes by Matrix mxc_id, and records each
+ * (mxc_id → convex_storage_id) mapping via /beeper/attachments/record.
+ *
+ * Phase A already ingested every message with its `attachments[].mxc_id`
+ * metadata. This script:
+ *
+ *   1. Walks Beeper's API once to enumerate every (mxc_id, srcURL, mime,
+ *      size) tuple referenced by messages in the given account.
+ *   2. Dedupes by mxc_id (same media file often appears in many messages).
+ *   3. Asks Convex which mxc_ids are already uploaded (resumable: skips them).
+ *   4. For each missing mxc_id, in parallel:
+ *        - Verify the file exists at the local srcURL path.
+ *        - Ask Convex for an upload URL.
+ *        - PUT the bytes — Convex returns a { storageId } on success.
+ *        - POST the storage id + metadata to /beeper/attachments/record.
+ *   5. Logs progress and saves a local manifest (.beeper-attachments-progress.json)
+ *      so subsequent runs only re-fetch attachment metadata from Beeper.
+ *
+ * Usage:
+ *   bun run scripts/upload-beeper-attachments.ts                        # WhatsApp
+ *   bun run scripts/upload-beeper-attachments.ts --account gmessages    # SMS
+ *   bun run scripts/upload-beeper-attachments.ts --limit 10 --dry-run   # smoke test
+ *   bun run scripts/upload-beeper-attachments.ts --concurrency 16
+ *
+ * Env (read from .env.local):
+ *   BEEPER_URL                 (default http://localhost:23373/v1)
+ *   BEEPER_ACCESS_TOKEN
+ *   CONVEX_INGEST_URL          base URL for /beeper/* (no trailing path)
+ *   BEEPER_INGEST_SECRET
+ */
+
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------- args + env -------------------------------------
+
+type Args = {
+  account: string;
+  limit?: number;
+  concurrency: number;
+  dryRun: boolean;
+  refresh: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { account: "whatsapp", concurrency: 8, dryRun: false, refresh: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--account") args.account = argv[++i] ?? args.account;
+    else if (a === "--limit") args.limit = Number(argv[++i]);
+    else if (a === "--concurrency") args.concurrency = Math.max(1, Number(argv[++i]));
+    else if (a === "--dry-run") args.dryRun = true;
+    else if (a === "--refresh") args.refresh = true;
+    else if (a === "--help" || a === "-h") { console.log(usage()); process.exit(0); }
+  }
+  return args;
+}
+
+function usage(): string {
+  return `Usage: bun run scripts/upload-beeper-attachments.ts [--account whatsapp] [--limit N] [--concurrency N] [--dry-run] [--refresh]`;
+}
+
+const ARGS = parseArgs(Bun.argv.slice(2));
+
+const BEEPER_URL = process.env.BEEPER_URL ?? "http://localhost:23373/v1";
+const BEEPER_TOKEN = process.env.BEEPER_ACCESS_TOKEN;
+const INGEST_BASE = (process.env.CONVEX_INGEST_URL ?? "").replace(/\/beeper\/ingest\/?$/, "");
+const INGEST_SECRET = process.env.BEEPER_INGEST_SECRET;
+
+if (!BEEPER_TOKEN) die("BEEPER_ACCESS_TOKEN not set");
+if (!ARGS.dryRun && !INGEST_BASE) die("CONVEX_INGEST_URL not set");
+if (!ARGS.dryRun && !INGEST_SECRET) die("BEEPER_INGEST_SECRET not set");
+
+const PROGRESS_PATH = join(import.meta.dir, ".beeper-attachments-progress.json");
+
+const ENDPOINTS = {
+  discover: `${INGEST_BASE}/beeper/attachments/discover`,
+  uploadUrl: `${INGEST_BASE}/beeper/attachments/uploadUrl`,
+  record: `${INGEST_BASE}/beeper/attachments/record`,
+};
+
+// ---------------------------- types ------------------------------------------
+
+type AttachmentMeta = {
+  mxc_id: string;
+  network: string;
+  src_path: string;
+  mime_type?: string;
+  file_name?: string;
+  file_size?: number;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+};
+
+interface BeeperListResp<T> { items: T[]; hasMore: boolean; oldestCursor: string | null }
+
+interface BeeperChatLite { id: string; network: string; title?: string }
+
+interface BeeperAttachment {
+  id: string; type?: string; mimeType?: string; fileName?: string;
+  fileSize?: number; isGif?: boolean; isSticker?: boolean;
+  size?: { width?: number; height?: number }; duration?: number; srcURL?: string;
+}
+
+interface BeeperMessage {
+  id: string; chatID: string; timestamp?: string;
+  attachments?: BeeperAttachment[];
+}
+
+// ---------------------------- HTTP -------------------------------------------
+
+async function beeperGet<T>(path: string): Promise<T> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const res = await fetch(`${BEEPER_URL}${path}`, {
+        headers: { Authorization: `Bearer ${BEEPER_TOKEN}` },
+      });
+      if (!res.ok) throw new Error(`Beeper ${res.status} ${res.statusText} for ${path}`);
+      return (await res.json()) as T;
+    } catch (e) {
+      if (attempt === 4) throw e;
+      await sleep(250 * 2 ** attempt);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+async function convexPost<T>(url: string, body: unknown): Promise<T> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: `Bearer ${INGEST_SECRET}` },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`POST ${url} → ${res.status} ${res.statusText}: ${text}`);
+      }
+      return (await res.json()) as T;
+    } catch (e) {
+      if (attempt === 4) throw e;
+      await sleep(500 * 2 ** attempt);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+// ---------------------------- collect attachments -----------------------------
+
+async function fetchAllChats(account: string): Promise<BeeperChatLite[]> {
+  const chats: BeeperChatLite[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const qs = new URLSearchParams({ accountIDs: account, limit: "200" });
+    if (cursor) qs.set("cursor", cursor);
+    const data = await beeperGet<BeeperListResp<BeeperChatLite>>(
+      `/chats/search?${qs.toString()}`,
+    );
+    chats.push(...data.items);
+    if (!data.hasMore || !data.oldestCursor) break;
+    cursor = data.oldestCursor;
+    await sleep(20);
+  }
+  return chats;
+}
+
+async function fetchAttachmentsForChat(chat: BeeperChatLite): Promise<AttachmentMeta[]> {
+  const enc = encodeURIComponent(chat.id);
+  const out: AttachmentMeta[] = [];
+  let cursor: string | null = null;
+  while (true) {
+    const qs = new URLSearchParams({ limit: "500" });
+    if (cursor) qs.set("cursor", cursor);
+    const data = await beeperGet<BeeperListResp<BeeperMessage>>(
+      `/chats/${enc}/messages?${qs.toString()}`,
+    );
+    for (const m of data.items) {
+      for (const a of m.attachments ?? []) {
+        if (!a.id) continue;
+        const srcPath = a.srcURL ? fileURLToLocalPath(a.srcURL) : undefined;
+        if (!srcPath) continue;
+        out.push({
+          mxc_id: a.id,
+          network: chat.network,
+          src_path: srcPath,
+          mime_type: a.mimeType,
+          file_name: a.fileName,
+          file_size: a.fileSize,
+          width: a.size?.width,
+          height: a.size?.height,
+          duration_ms: a.duration,
+        });
+      }
+    }
+    if (!data.hasMore || !data.oldestCursor) break;
+    cursor = data.oldestCursor;
+    await sleep(20);
+  }
+  return out;
+}
+
+function fileURLToLocalPath(srcURL: string): string | undefined {
+  if (!srcURL.startsWith("file://")) return undefined;
+  try {
+    return fileURLToPath(srcURL);
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------- progress ---------------------------------------
+
+type Progress = {
+  account: string;
+  uploaded: Record<string, string>; // mxc_id → storage_id
+  failed: Record<string, string>;   // mxc_id → last error
+  updatedAt: string;
+};
+
+function loadProgress(account: string): Progress {
+  if (!existsSync(PROGRESS_PATH)) {
+    return { account, uploaded: {}, failed: {}, updatedAt: new Date().toISOString() };
+  }
+  const all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<string, Progress>;
+  return all[account] ?? {
+    account, uploaded: {}, failed: {}, updatedAt: new Date().toISOString(),
+  };
+}
+
+function saveProgress(p: Progress): void {
+  let all: Record<string, Progress> = {};
+  if (existsSync(PROGRESS_PATH)) {
+    all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<string, Progress>;
+  }
+  p.updatedAt = new Date().toISOString();
+  all[p.account] = p;
+  writeFileSync(PROGRESS_PATH, JSON.stringify(all, null, 2));
+}
+
+// ---------------------------- upload one --------------------------------------
+
+async function uploadOne(att: AttachmentMeta): Promise<{ ok: true; storageId: string } | { ok: false; error: string }> {
+  if (!existsSync(att.src_path)) {
+    return { ok: false, error: `missing local file: ${att.src_path}` };
+  }
+  let onDiskSize: number | undefined;
+  try {
+    onDiskSize = statSync(att.src_path).size;
+  } catch (e) {
+    return { ok: false, error: `stat failed: ${(e as Error).message}` };
+  }
+
+  // 1) ask for an upload URL
+  let uploadUrl: string;
+  try {
+    const resp = await convexPost<{ uploadUrl: string }>(ENDPOINTS.uploadUrl, {});
+    uploadUrl = resp.uploadUrl;
+  } catch (e) {
+    return { ok: false, error: `uploadUrl: ${(e as Error).message}` };
+  }
+
+  // 2) PUT the bytes (Convex's upload URL expects POST with the file body)
+  let storageId: string;
+  try {
+    const file = Bun.file(att.src_path);
+    const res = await fetch(uploadUrl, {
+      method: "POST",
+      headers: att.mime_type ? { "Content-Type": att.mime_type } : {},
+      body: file,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      return { ok: false, error: `upload PUT ${res.status}: ${text}` };
+    }
+    const json = (await res.json()) as { storageId?: string };
+    if (!json.storageId) return { ok: false, error: "upload response missing storageId" };
+    storageId = json.storageId;
+  } catch (e) {
+    return { ok: false, error: `upload bytes: ${(e as Error).message}` };
+  }
+
+  // 3) record the mapping
+  try {
+    await convexPost(ENDPOINTS.record, {
+      mxc_id: att.mxc_id,
+      convex_storage_id: storageId,
+      network: att.network,
+      mime_type: att.mime_type,
+      file_name: att.file_name,
+      file_size: att.file_size ?? onDiskSize,
+      width: att.width,
+      height: att.height,
+      duration_ms: att.duration_ms,
+    });
+  } catch (e) {
+    return { ok: false, error: `record: ${(e as Error).message}` };
+  }
+
+  return { ok: true, storageId };
+}
+
+// ---------------------------- main -------------------------------------------
+
+function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout(r, ms)); }
+function die(msg: string): never { console.error(`error: ${msg}`); process.exit(1); }
+
+async function main(): Promise<void> {
+  console.log(`Beeper attachments uploader — account=${ARGS.account} concurrency=${ARGS.concurrency} dryRun=${ARGS.dryRun}`);
+
+  // 1) enumerate chats
+  console.log(`\n[1/4] fetching all chats for ${ARGS.account}...`);
+  const chats = await fetchAllChats(ARGS.account);
+  console.log(`  found ${chats.length} chats`);
+
+  // 2) collect attachment refs (dedupe by mxc_id, keep first occurrence)
+  console.log(`\n[2/4] collecting attachment refs from messages...`);
+  const byMxc = new Map<string, AttachmentMeta>();
+  let scanned = 0;
+  for (const c of chats) {
+    let atts: AttachmentMeta[];
+    try { atts = await fetchAttachmentsForChat(c); }
+    catch (e) { console.error(`  ! chat ${c.title ?? c.id}: ${(e as Error).message}`); continue; }
+    for (const a of atts) if (!byMxc.has(a.mxc_id)) byMxc.set(a.mxc_id, a);
+    scanned += 1;
+    if (scanned % 25 === 0 || scanned === chats.length) {
+      console.log(`  scanned ${scanned}/${chats.length} chats, unique attachments so far: ${byMxc.size}`);
+    }
+  }
+  const allAttachments = Array.from(byMxc.values());
+  console.log(`  total unique attachments: ${allAttachments.length}`);
+
+  // 3) ask Convex which we've already uploaded; merge with local progress
+  let toUpload: AttachmentMeta[] = allAttachments;
+  const progress = loadProgress(ARGS.account);
+  if (!ARGS.refresh) {
+    if (!ARGS.dryRun) {
+      console.log(`\n[3/4] checking Convex for previously-uploaded attachments...`);
+      const allMxc = allAttachments.map((a) => a.mxc_id);
+      const knownUploaded = new Set<string>(Object.keys(progress.uploaded));
+      const chunk = 200;
+      for (let i = 0; i < allMxc.length; i += chunk) {
+        const slice = allMxc.slice(i, i + chunk);
+        const resp = await convexPost<{ uploaded: { mxc_id: string; convex_storage_id: string }[]; missing: string[] }>(
+          ENDPOINTS.discover, { mxc_ids: slice },
+        );
+        for (const u of resp.uploaded) {
+          knownUploaded.add(u.mxc_id);
+          progress.uploaded[u.mxc_id] = u.convex_storage_id;
+        }
+      }
+      saveProgress(progress);
+      toUpload = allAttachments.filter((a) => !knownUploaded.has(a.mxc_id));
+      console.log(`  ${knownUploaded.size} already uploaded, ${toUpload.length} remaining`);
+    } else {
+      toUpload = allAttachments.filter((a) => !progress.uploaded[a.mxc_id]);
+      console.log(`\n[3/4] (dry-run) skipping discover; ${toUpload.length} would be uploaded`);
+    }
+  } else {
+    console.log(`\n[3/4] --refresh: uploading all ${toUpload.length} attachments`);
+  }
+
+  if (ARGS.limit !== undefined) toUpload = toUpload.slice(0, ARGS.limit);
+  const totalBytes = toUpload.reduce((sum, a) => sum + (a.file_size ?? 0), 0);
+  console.log(`  to upload now: ${toUpload.length} (${(totalBytes / (1024 * 1024)).toFixed(1)} MiB est.)`);
+
+  if (ARGS.dryRun || toUpload.length === 0) {
+    console.log(`\ndone (${ARGS.dryRun ? "dry-run" : "nothing to do"}).`);
+    return;
+  }
+
+  // 4) parallel upload with bounded concurrency
+  console.log(`\n[4/4] uploading at concurrency=${ARGS.concurrency}...`);
+  let done = 0;
+  let okCount = 0;
+  let failCount = 0;
+  let bytes = 0;
+  const started = Date.now();
+
+  let cursor = 0;
+  async function worker(id: number): Promise<void> {
+    while (true) {
+      const idx = cursor++;
+      if (idx >= toUpload.length) return;
+      const att = toUpload[idx]!;
+      const result = await uploadOne(att);
+      if (result.ok) {
+        progress.uploaded[att.mxc_id] = result.storageId;
+        delete progress.failed[att.mxc_id];
+        okCount += 1;
+        bytes += att.file_size ?? 0;
+      } else {
+        progress.failed[att.mxc_id] = result.error;
+        failCount += 1;
+      }
+      done += 1;
+      // Save progress every 25 finished attachments so a crash doesn't lose much.
+      if (done % 25 === 0 || done === toUpload.length) {
+        saveProgress(progress);
+        const elapsed = (Date.now() - started) / 1000;
+        const rate = done / Math.max(elapsed, 0.001);
+        const mbps = bytes / (1024 * 1024) / Math.max(elapsed, 0.001);
+        const eta = (toUpload.length - done) / Math.max(rate, 0.001);
+        console.log(
+          `  [w${id}] done ${done}/${toUpload.length}  ok=${okCount} fail=${failCount}  ` +
+          `${(bytes / (1024 * 1024)).toFixed(1)} MiB  ${mbps.toFixed(2)} MiB/s  ` +
+          `eta ${eta.toFixed(0)}s`,
+        );
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: ARGS.concurrency }, (_, i) => worker(i + 1)),
+  );
+
+  saveProgress(progress);
+  const elapsed = (Date.now() - started) / 1000;
+  console.log(
+    `\ndone. uploaded=${okCount} failed=${failCount} ` +
+    `bytes=${(bytes / (1024 * 1024)).toFixed(1)} MiB elapsed=${elapsed.toFixed(1)}s`,
+  );
+
+  if (failCount > 0) {
+    console.log(`\nFailed mxc_ids (last error each):`);
+    const failed = Object.entries(progress.failed).slice(0, 20);
+    for (const [mxc, err] of failed) console.log(`  ${mxc}: ${err}`);
+    if (Object.keys(progress.failed).length > failed.length) {
+      console.log(`  ... and ${Object.keys(progress.failed).length - failed.length} more`);
+    }
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/upload-beeper-attachments.ts
+++ b/scripts/upload-beeper-attachments.ts
@@ -41,6 +41,7 @@ import { fileURLToPath } from "node:url";
 type Args = {
   account: string;
   limit?: number;
+  limitChats?: number;
   concurrency: number;
   dryRun: boolean;
   refresh: boolean;
@@ -52,6 +53,7 @@ function parseArgs(argv: string[]): Args {
     const a = argv[i];
     if (a === "--account") args.account = argv[++i] ?? args.account;
     else if (a === "--limit") args.limit = Number(argv[++i]);
+    else if (a === "--limit-chats") args.limitChats = Number(argv[++i]);
     else if (a === "--concurrency") args.concurrency = Math.max(1, Number(argv[++i]));
     else if (a === "--dry-run") args.dryRun = true;
     else if (a === "--refresh") args.refresh = true;
@@ -61,7 +63,7 @@ function parseArgs(argv: string[]): Args {
 }
 
 function usage(): string {
-  return `Usage: bun run scripts/upload-beeper-attachments.ts [--account whatsapp] [--limit N] [--concurrency N] [--dry-run] [--refresh]`;
+  return `Usage: bun run scripts/upload-beeper-attachments.ts [--account whatsapp] [--limit-chats N] [--limit N] [--concurrency N] [--dry-run] [--refresh]`;
 }
 
 const ARGS = parseArgs(Bun.argv.slice(2));
@@ -218,18 +220,32 @@ function fileURLToLocalPath(srcURL: string): string | undefined {
 
 type Progress = {
   account: string;
+  deployment: string;
   uploaded: Record<string, string>; // mxc_id → storage_id
   failed: Record<string, string>;   // mxc_id → last error
   updatedAt: string;
 };
 
+// Storage IDs are deployment-scoped, so we key progress by (deployment_host,
+// account). Same script, two deployments → two independent buckets.
+function deploymentKey(): string {
+  if (ARGS.dryRun) return "dry-run";
+  try { return new URL(INGEST_BASE).host; } catch { return "unknown"; }
+}
+
+function progressKey(account: string): string {
+  return `${deploymentKey()}::${account}`;
+}
+
 function loadProgress(account: string): Progress {
+  const key = progressKey(account);
   if (!existsSync(PROGRESS_PATH)) {
-    return { account, uploaded: {}, failed: {}, updatedAt: new Date().toISOString() };
+    return { account, deployment: deploymentKey(), uploaded: {}, failed: {}, updatedAt: new Date().toISOString() };
   }
   const all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<string, Progress>;
-  return all[account] ?? {
-    account, uploaded: {}, failed: {}, updatedAt: new Date().toISOString(),
+  return all[key] ?? {
+    account, deployment: deploymentKey(),
+    uploaded: {}, failed: {}, updatedAt: new Date().toISOString(),
   };
 }
 
@@ -239,7 +255,7 @@ function saveProgress(p: Progress): void {
     all = JSON.parse(readFileSync(PROGRESS_PATH, "utf8")) as Record<string, Progress>;
   }
   p.updatedAt = new Date().toISOString();
-  all[p.account] = p;
+  all[progressKey(p.account)] = p;
   writeFileSync(PROGRESS_PATH, JSON.stringify(all, null, 2));
 }
 
@@ -315,8 +331,12 @@ async function main(): Promise<void> {
 
   // 1) enumerate chats
   console.log(`\n[1/4] fetching all chats for ${ARGS.account}...`);
-  const chats = await fetchAllChats(ARGS.account);
+  let chats = await fetchAllChats(ARGS.account);
   console.log(`  found ${chats.length} chats`);
+  if (ARGS.limitChats !== undefined) {
+    chats = chats.slice(0, ARGS.limitChats);
+    console.log(`  capped at ${chats.length} chats (--limit-chats)`);
+  }
 
   // 2) collect attachment refs (dedupe by mxc_id, keep first occurrence)
   console.log(`\n[2/4] collecting attachment refs from messages...`);


### PR DESCRIPTION
Mirrors Beeper Desktop's message history into Convex. WhatsApp is the first network; the same schema and ingest path handle Telegram / iMessage / Slack / Google Messages / Matrix by changing `--account` on the local sync script.

## What's in this PR (Phase A)

- **Schema** — new tables under `convex/schema/beeper/`:
  - `beeper_accounts` (one per connected network)
  - `beeper_chats` (keyed by Beeper/Matrix room id)
  - `beeper_messages` ((chat_id, message_id), with a `searchIndex` on `text` filterable by chat / network / sender / type / direction)
- **Ingest** — `POST /beeper/ingest` httpAction with shared-secret bearer auth (`BEEPER_INGEST_SECRET`). Batched payload, calls into internal mutations that idempotently upsert.
- **Internal mutations** — `upsertAccount`, `upsertChat`, `upsertMessages` (per-chat batch), `markAccountSynced`. Tests for transformation logic alongside.
- **Queries** — `getRecentChats`, `getMessagesByChat`, `searchMessages`, `getSyncStatus`. All scoped so they don't blow Convex's 16 MB per-query read budget (the early version of `getSyncStatus` did — fixed mid-PR after the 20k-message backfill caught it).
- **Local Bun script** — `scripts/sync-beeper.ts` reads from Beeper's localhost API and POSTs batches. Resumable via `scripts/.beeper-sync-progress.json`. Supports `--account`, `--since-days`, `--limit-chats`, `--refresh`, `--dry-run`.
- **ESLint** — adds a `scripts/**/*.ts` config block (Node globals, `no-console` relaxed) since the script's stdout is its UX.

## Verified

Backfilled all of WhatsApp into prod (`blessed-egret-906`):

- **584 chats, 20,491 messages, 5min 46s.**
- Full-text search hits messages from 2023 / 2024 / 2025 / 2026.
- All 164 vitest tests pass; my new files pass lint (repo has unrelated pre-existing lint debt on `main`, not addressed here).

## Why local-push instead of Convex-pull

Beeper's API only exists at `localhost:23373` on Milad's machines — Convex-hosted actions can't reach it. So ingest originates on the laptop or Mac Mini running the Bun script. Phase C (later) will turn that into a long-running WebSocket subscriber for realtime updates, via launchd.

## Followups not in this PR

- **Phase B**: upload referenced attachment bytes (~29 GB of cached media) to Convex File Storage with a dedupe table by `mxc_id`. Schema already accommodates `convex_storage_id` on each attachment without migration.
- **Phase C**: realtime WebSocket subscriber on the Mac Mini.
- **Phase D**: other networks (`--account telegram|...`).
- The Convex skill at `~/.claude/skills/convex/SKILL.md` points at a different deployment (`fiery-swan-195`) than this codebase's prod (`blessed-egret-906`). Worth reconciling separately.

## Schema drift dropped at deploy

`bunx convex deploy` removed indexes on `users`, `auth*`, `agenticThread*`, `agenticRuns` — those tables were not in `schema.ts` to begin with. Confirmed dead with Milad before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)