### PR TITLE
fix(imsg): validate client build environment

### DIFF
--- a/apps/imsg/.env.example
+++ b/apps/imsg/.env.example
@@ -4,9 +4,13 @@ PORT=8377
 DB_PATH=imsg.db
 
 # Identity graph (Apple Contacts -> master-db). Optional — contact sync is
-# skipped with a log line if either is unset.
+# skipped with a log line if either site URL or ingest secret is unset.
 CONVEX_SITE_URL=https://shiny-gerbil-853.convex.site
 APPLE_CONTACTS_INGEST_SECRET=
+# Identity mirror and CRM queries. IMSG_IDENTITY_KEY must also be configured
+# in Convex and copied to client/.env as EXPO_PUBLIC_IMSG_IDENTITY_KEY.
+CONVEX_CLOUD_URL=https://shiny-gerbil-853.convex.cloud
+IMSG_IDENTITY_KEY=
 
 # Optional local whisper.cpp transcription. The app remains available when unset.
 WHISPER_BINARY_PATH=/absolute/path/to/whisper-cli

--- a/apps/imsg/README.md
+++ b/apps/imsg/README.md
@@ -32,9 +32,10 @@ Expo/React-Native-Web app  ←SSE + JSON→  Bun/Hono server  ←REST + socket.i
 
 ```sh
 bun install
-cp .env.example .env   # set BB_PASSWORD
-bun run build          # exports the Expo web app to client/dist/
-bun start              # serves app + API on :8377
+cp .env.example .env                 # set server values, including BB_PASSWORD
+cp client/.env.example client/.env   # set both required Expo public values
+bun run build                        # exports the Expo web app to client/dist/
+bun start                            # serves app + API on :8377
 ```
 
 Dev: `bun run dev:server` for the API; `cd client && bun run start` for the Expo dev server
@@ -48,6 +49,18 @@ Dev: `bun run dev:server` for the API; `cd client && bun run start` for the Expo
 | `BB_PASSWORD` | — | required |
 | `PORT` | `8377` | |
 | `DB_PATH` | `imsg.db` | overlay SQLite |
+| `CONVEX_CLOUD_URL` | — | optional identity mirror and CRM deployment URL |
+| `IMSG_IDENTITY_KEY` | — | shared identity gate; must match Convex and `client/.env` |
 | `WHISPER_BINARY_PATH` | — | optional local `whisper-cli` binary |
 | `WHISPER_MODEL_PATH` | — | optional local multilingual ggml model |
 | `WHISPER_WORK_DIR` | `.cache/whisper` | ephemeral conversion files |
+
+The Expo client reads a separate `client/.env` when exporting web or starting Metro:
+
+| var | default | |
+|---|---|---|
+| `EXPO_PUBLIC_CONVEX_URL` | — | required absolute HTTP(S) Convex deployment URL |
+| `EXPO_PUBLIC_IMSG_IDENTITY_KEY` | — | required; must match the Convex deployment's `IMSG_IDENTITY_KEY` |
+
+Both client values are embedded in the bundle. The identity key is a coarse shared gate,
+not a confidential browser secret. Builds fail before export when either value is absent.

--- a/apps/imsg/client/.env.example
+++ b/apps/imsg/client/.env.example
@@ -1,1 +1,4 @@
 EXPO_PUBLIC_CONVEX_URL=https://shiny-gerbil-853.convex.cloud
+# Must match IMSG_IDENTITY_KEY in the Convex deployment and apps/imsg/.env.
+# This is embedded in the client bundle as a coarse shared gate, not a secret.
+EXPO_PUBLIC_IMSG_IDENTITY_KEY=

--- a/apps/imsg/client/.gitignore
+++ b/apps/imsg/client/.gitignore
@@ -31,7 +31,8 @@ yarn-error.*
 *.pem
 
 # local env files
-.env*.local
+.env*
+!.env.example
 
 # typescript
 *.tsbuildinfo

--- a/apps/imsg/client/package.json
+++ b/apps/imsg/client/package.json
@@ -56,7 +56,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint",
-    "build:web": "expo export --platform web && bun scripts/post-export.ts"
+    "build:web": "bun scripts/validate-public-env.ts && expo export --platform web && bun scripts/post-export.ts"
   },
   "private": true
 }

--- a/apps/imsg/client/scripts/validate-public-env.ts
+++ b/apps/imsg/client/scripts/validate-public-env.ts
@@ -1,0 +1,13 @@
+import { validateConvexUrl, validateIdentityKey } from "../src/lib/public-env";
+
+const results = [
+  validateConvexUrl(process.env.EXPO_PUBLIC_CONVEX_URL),
+  validateIdentityKey(process.env.EXPO_PUBLIC_IMSG_IDENTITY_KEY),
+];
+const errors = results.flatMap((result) => result.ok ? [] : [result.error]);
+if (errors.length > 0) {
+  for (const error of errors) console.error(`Client build aborted: ${error}`);
+  process.exit(1);
+}
+
+console.log("Client public environment validated");

--- a/apps/imsg/client/src/lib/identity.ts
+++ b/apps/imsg/client/src/lib/identity.ts
@@ -1,5 +1,6 @@
 import { ConvexReactClient, useAction, useMutation, useQuery } from "convex/react";
 import { makeFunctionReference } from "convex/server";
+import { requireConvexUrl, requireIdentityKey } from "./public-env";
 
 /**
  * imsg is not part of the master-db Convex build (Metro can't safely cross
@@ -11,7 +12,7 @@ import { makeFunctionReference } from "convex/server";
  */
 
 export const convexClient = new ConvexReactClient(
-  process.env.EXPO_PUBLIC_CONVEX_URL ?? "",
+  requireConvexUrl(process.env.EXPO_PUBLIC_CONVEX_URL),
   { unsavedChangesWarning: false },
 );
 
@@ -22,7 +23,7 @@ export const convexClient = new ConvexReactClient(
  * load; every hook below injects it so no call-site elsewhere in the client
  * needs to know it exists.
  */
-const IDENTITY_KEY = process.env.EXPO_PUBLIC_IMSG_IDENTITY_KEY ?? "";
+const IDENTITY_KEY = requireIdentityKey(process.env.EXPO_PUBLIC_IMSG_IDENTITY_KEY);
 
 export type IdentityRow = {
   kind: string;

--- a/apps/imsg/client/src/lib/public-env.test.ts
+++ b/apps/imsg/client/src/lib/public-env.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+  requireConvexUrl,
+  requireIdentityKey,
+  validateConvexUrl,
+  validateIdentityKey,
+} from "./public-env";
+
+describe("Convex public URL validation", () => {
+  test("accepts absolute HTTP and HTTPS URLs", () => {
+    expect(validateConvexUrl("https://example.convex.cloud")).toEqual({
+      ok: true,
+      value: "https://example.convex.cloud",
+    });
+    expect(validateConvexUrl("http://localhost:3210")).toEqual({
+      ok: true,
+      value: "http://localhost:3210",
+    });
+  });
+
+  test("rejects missing and relative URLs before Convex initializes", () => {
+    expect(validateConvexUrl(undefined)).toEqual({
+      ok: false,
+      error: "EXPO_PUBLIC_CONVEX_URL is required",
+    });
+    expect(validateConvexUrl("/convex")).toEqual({
+      ok: false,
+      error: "EXPO_PUBLIC_CONVEX_URL must be an absolute HTTP(S) URL",
+    });
+    expect(() => requireConvexUrl("")).toThrow("EXPO_PUBLIC_CONVEX_URL is required");
+  });
+
+  test("rejects non-HTTP URL schemes", () => {
+    expect(validateConvexUrl("file:///tmp/convex")).toEqual({
+      ok: false,
+      error: "EXPO_PUBLIC_CONVEX_URL must be an absolute HTTP(S) URL",
+    });
+  });
+
+  test("requires the identity key embedded in the client", () => {
+    expect(validateIdentityKey("identity-key")).toEqual({
+      ok: true,
+      value: "identity-key",
+    });
+    expect(validateIdentityKey("  ")).toEqual({
+      ok: false,
+      error: "EXPO_PUBLIC_IMSG_IDENTITY_KEY is required",
+    });
+    expect(() => requireIdentityKey(undefined)).toThrow(
+      "EXPO_PUBLIC_IMSG_IDENTITY_KEY is required",
+    );
+  });
+});

--- a/apps/imsg/client/src/lib/public-env.ts
+++ b/apps/imsg/client/src/lib/public-env.ts
@@ -1,0 +1,46 @@
+export type PublicEnvResult =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+/** Validates the URL Expo embeds into the client bundle at export time. */
+export function validateConvexUrl(value: string | undefined): PublicEnvResult {
+  const url = value?.trim() ?? "";
+  if (!url) {
+    return { ok: false, error: "EXPO_PUBLIC_CONVEX_URL is required" };
+  }
+  try {
+    const protocol = new URL(url).protocol;
+    if (protocol !== "http:" && protocol !== "https:") {
+      return {
+        ok: false,
+        error: "EXPO_PUBLIC_CONVEX_URL must be an absolute HTTP(S) URL",
+      };
+    }
+  } catch {
+    return {
+      ok: false,
+      error: "EXPO_PUBLIC_CONVEX_URL must be an absolute HTTP(S) URL",
+    };
+  }
+  return { ok: true, value: url };
+}
+
+export function requireConvexUrl(value: string | undefined): string {
+  const result = validateConvexUrl(value);
+  if (!result.ok) throw new Error(result.error);
+  return result.value;
+}
+
+export function validateIdentityKey(value: string | undefined): PublicEnvResult {
+  const key = value?.trim() ?? "";
+  if (!key) {
+    return { ok: false, error: "EXPO_PUBLIC_IMSG_IDENTITY_KEY is required" };
+  }
+  return { ok: true, value: key };
+}
+
+export function requireIdentityKey(value: string | undefined): string {
+  const result = validateIdentityKey(value);
+  if (!result.ok) throw new Error(result.error);
+  return result.value;
+}

--- a/apps/imsg/scripts/deploy.sh
+++ b/apps/imsg/scripts/deploy.sh
@@ -54,6 +54,7 @@ bun run typecheck:imsg
 
 echo "== Building web client =="
 cd apps/imsg/client
+bun scripts/validate-public-env.ts
 rm -rf dist
 BUILD_LOG="$(mktemp)"
 bun x expo export --platform web >"$BUILD_LOG" 2>&1 &


### PR DESCRIPTION
## What changed
- fail web exports when the Convex URL or client identity key is missing
- validate the same values before Convex initializes at runtime
- cover the Mini deployment path and document client env provisioning

## Root cause
The message-parity web export was built from an isolated worktree without `apps/imsg/client/.env`, so Expo embedded an empty Convex URL and the Chrome app crashed during module initialization.

## Validation
- 347 Bun tests pass
- client and server TypeScript pass
- oxlint has zero errors (existing warnings only)
- Expo web export passes with both required values
- Playwright startup repro is green against the rebuilt bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)